### PR TITLE
Show error when ssh keys are not setup - UpdateRemoteDirect screen

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -397,9 +397,16 @@ async function readChildProcessOutput(readable) {
 
 async function parseSSHConfigFile() {
   try {
+    const initialValue = { github: [], bitbucket: [], gitlab: [] };
+
+    if (!fs.existsSync(sshConfigFileLocation)) {
+      return initialValue;
+    }
+
     const sshConfigFileContents = await readFileAsync(sshConfigFileLocation, {
       encoding: 'utf8',
     });
+
     // Using ssh-config lib from npm to parse the contents of ssh config file
     // and converting it into meaningful object which we could use for
     // direct clone repo/update remote functionality
@@ -409,8 +416,6 @@ async function parseSSHConfigFile() {
     // Reducing values based on "host" by separating username from it.
     // Below logic is reducing only host who have values like `github-username`, `bitbucket-username` or `gitlab-username`.
     // and ignoring rest.
-    const initialValue = { github: [], bitbucket: [], gitlab: [] };
-
     const result = hosts.reduce((accumulator, host) => {
       if (!host.includes('-')) return accumulator;
 

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -399,6 +399,7 @@ async function parseSSHConfigFile() {
   try {
     const initialValue = { github: [], bitbucket: [], gitlab: [] };
 
+    // When ssh file doesn't exists do early return with default values.
     if (!fs.existsSync(sshConfigFileLocation)) {
       return initialValue;
     }

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -24,7 +24,7 @@ export default function UpdateRemoteDirect() {
   const [repoFolder, setRepoFolder] = useState(''); // Stores repoFolder user selects for which they are updating "remote url"
 
   const [sshConfig, setSshConfig] = useState({}); // Stores config values coming from .ssh config file.
-  const [noKeysSetupError, setNoKeysSetupError] = useState(false);
+  const [noKeysSetupError, setNoKeysSetupError] = useState(false); // Stores state to determine whether to show ssh keys not setup error at top of dialog or not.
 
   // Custom hook to handle account options to select and render
   const [account, setAccount, AccountDropdown] = useDropdown(
@@ -62,6 +62,10 @@ export default function UpdateRemoteDirect() {
     getSshConfig();
   }, []);
 
+  // Effect to check whether ssh keys are setup correctly
+  // based on parsed `sshconfig` value received from the main process
+  // using the above effect.
+  // If keys are not setup, we set `noKeySetupError` state to true for showing error to user in such case.
   useEffect(() => {
     if (Object.keys(sshConfig).length > 0) {
       const [githubKeys, bitbucketKeys, gitlabKeys] = Object.values(sshConfig);
@@ -76,15 +80,16 @@ export default function UpdateRemoteDirect() {
   }, [sshConfig]);
 
   useEffect(() => {
-    // Making sure that we ask for desktop folder path only
-    // when `selectedFolder` is empty('') which would happen
-    // in case "clone repo" dialog is closed and re-opened again and during 1st time when selectedFolder isn't set yet.
     async function getSystemDesktopFolderPath() {
       const desktopFolderPath = await window.ipc.callMain(
         'get-system-desktop-path'
       );
       setSelectedFolder(desktopFolderPath);
     }
+
+    // Making sure that we ask for desktop folder path only
+    // when `selectedFolder` is empty('') which would happen
+    // in case "clone repo" dialog is closed and re-opened again and during 1st time when selectedFolder isn't set yet.
     if (!selectedFolder) {
       getSystemDesktopFolderPath();
     }

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -22,7 +22,9 @@ export default function UpdateRemoteDirect() {
   const [repoUrl, setRepoUrl] = useState(''); // Stores repourl entered by user
   const [selectedFolder, setSelectedFolder] = useState(''); // Stores selected folder where to clone the repo
   const [repoFolder, setRepoFolder] = useState(''); // Stores repoFolder user selects for which they are updating "remote url"
+
   const [sshConfig, setSshConfig] = useState({}); // Stores config values coming from .ssh config file.
+  const [noKeysSetupError, setNoKeysSetupError] = useState(false);
 
   // Custom hook to handle account options to select and render
   const [account, setAccount, AccountDropdown] = useDropdown(
@@ -61,6 +63,19 @@ export default function UpdateRemoteDirect() {
   }, []);
 
   useEffect(() => {
+    if (Object.keys(sshConfig).length > 0) {
+      const [githubKeys, bitbucketKeys, gitlabKeys] = Object.values(sshConfig);
+      if (
+        githubKeys.length === 0 &&
+        bitbucketKeys.length === 0 &&
+        gitlabKeys.length === 0
+      ) {
+        setNoKeysSetupError(true);
+      }
+    }
+  }, [sshConfig]);
+
+  useEffect(() => {
     // Making sure that we ask for desktop folder path only
     // when `selectedFolder` is empty('') which would happen
     // in case "clone repo" dialog is closed and re-opened again and during 1st time when selectedFolder isn't set yet.
@@ -75,9 +90,7 @@ export default function UpdateRemoteDirect() {
     }
   }, [selectedFolder]);
 
-  function goBackToHomeScreen() {
-    history.navigate('');
-  }
+  // Click Listeners
 
   // Click listener for "select folder" action
   async function onChangeDefaultFolderClicked() {
@@ -146,10 +159,38 @@ export default function UpdateRemoteDirect() {
     dispatch({ type: 'FETCH_RESET' });
   }
 
+  // Navigation methods
+
+  function navigateToHomeScreen() {
+    history.navigate('');
+  }
+
+  function navigateToSshSetupScreen() {
+    history.navigate('oauth/');
+  }
+
+  // Render functions
+
+  function renderNoKeysSetupError() {
+    return (
+      <>
+        <p className="text-base font-semibold text-red-600 mt-2">
+          You haven't setup ssh keys using this App.
+        </p>
+        <p
+          className="text-base underline font-semibold text-red-600 hover:text-red-700 cursor-pointer"
+          onClick={navigateToSshSetupScreen}>
+          Setup keys to start using this feature
+        </p>
+      </>
+    );
+  }
+
   function renderCloneRepoDialog() {
     return (
       <div>
         <h1 className="text-2xl font-semibold">Clone Repo</h1>
+        {noKeysSetupError && renderNoKeysSetupError()}
         <AccountDropdown />
         <UserNameDropDown />
         <label className="text-gray-800 block text-left text-base mt-6 font-semibold">
@@ -214,6 +255,7 @@ export default function UpdateRemoteDirect() {
     return (
       <div>
         <h1 className="text-2xl font-semibold">Update Remote Url</h1>
+        {noKeysSetupError && renderNoKeysSetupError()}
         <AccountDropdown />
         <UserNameDropDown />
         <label className="text-gray-800 block text-left text-base mt-4 font-semibold">
@@ -260,7 +302,7 @@ export default function UpdateRemoteDirect() {
 
   return (
     <div className="bg-gray-300 h-screen">
-      <Toolbar onBackPressed={goBackToHomeScreen} title="Update Remote" />
+      <Toolbar onBackPressed={navigateToHomeScreen} title="Update Remote" />
       <h2 className="mx-16 mt-8 text-2xl text-center text-gray-900">
         Clone Repo or Update Remote Url
       </h2>


### PR DESCRIPTION
**What:**
When user goes to clone/update remote screen directly without setting up ssh keys we need to show  error to the user indicating the same and provide link to `SSHSetup` screen.

**How:**
The logic of showing such error relies on ssh config file's contents. 
1. If the file is not present in **.ssh** folder?
OR 
2. If it doesn't contains **"host"** with value like `github-{username}` or `gitlab-{username}` or `bitbucket-{username}` ?

In above 2 cases, we assume user hasn't setup any keys using this app and ask them to do so by showing the error and providing link to SSHSetup screen.