### PR TITLE
Feat : Shallow Clone Repo

### DIFF
--- a/public/custom.css
+++ b/public/custom.css
@@ -115,3 +115,46 @@
 .u-lock-scroll {
   overflow: hidden !important;
 }
+
+.react-switch-checkbox {
+  height: 0;
+  width: 0;
+  visibility: hidden;
+}
+
+.react-switch-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  width: 48px;
+  height: 24px;
+  background: #cbd5e0;
+  border-radius: 24px;
+  position: relative;
+  transition: background-color 0.2s;
+}
+
+.react-switch-label .react-switch-button {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  right: 1px;
+  bottom: 1px;
+  width: 22px;
+  height: 22px;
+  border-radius: 20px;
+  transition: 0.2s;
+  background: #fff;
+  box-shadow: 0 0 2px 0 rgba(10, 10, 10, 0.29);
+}
+
+.react-switch-checkbox:checked + .react-switch-label .react-switch-button {
+  left: calc(100% - 1px);
+  transform: translateX(-100%);
+}
+
+.react-switch-label:active .react-switch-button {
+  width: 36px;
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -74,7 +74,8 @@ function getCloneRepoCommand(
   selectedProvider,
   username,
   repoUrl,
-  disableLogging = true
+  disableLogging = true,
+  shallowClone = false
 ) {
   let modifiedRepoUrl;
   if (selectedProvider === providers.BITBUCKET) {
@@ -89,7 +90,9 @@ function getCloneRepoCommand(
     );
   }
 
-  return `git clone ${modifiedRepoUrl} ${disableLogging ? `--quiet` : ''}`;
+  return `git clone ${modifiedRepoUrl} ${shallowClone ? '--depth=1' : ''} ${
+    disableLogging ? `--quiet` : ''
+  } `;
 }
 
 function getManualSteps(selectedProvider) {

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -193,7 +193,13 @@ async function getPublicKey(selectedProvider, username) {
  * @param {*} repoUrl - used to do some validations and clone the repo
  * @param {*} repoFolder - used to determine the path where to clone the repo.
  */
-async function cloneRepo(selectedProvider, username, repoUrl, selectedFolder) {
+async function cloneRepo(
+  selectedProvider,
+  username,
+  repoUrl,
+  selectedFolder,
+  shallowClone
+) {
   // Check if user has entered correct repo url based on currently selected provider
   if (
     repoUrl.startsWith('git@') &&
@@ -233,11 +239,14 @@ async function cloneRepo(selectedProvider, username, repoUrl, selectedFolder) {
     );
   }
 
+  const disableLogging = true;
   // Run clone command if everything looks good
   const cloneRepoCommand = getCloneRepoCommand(
     selectedProvider,
     username,
-    repoUrl
+    repoUrl,
+    disableLogging,
+    shallowClone
   );
 
   try {
@@ -260,7 +269,8 @@ async function cloneRepo(selectedProvider, username, repoUrl, selectedFolder) {
         selectedProvider,
         username,
         repoUrl,
-        repoFolder
+        repoFolder,
+        shallowClone
       );
       return result;
     } else {
@@ -276,13 +286,16 @@ async function runCloneRepoCommandUsingNodePty(
   selectedProvider,
   username,
   repoUrl,
-  repoFolder
+  repoFolder,
+  shallowClone
 ) {
+  const disableLogging = false;
   const cloneRepoCommand = getCloneRepoCommand(
     selectedProvider,
     username,
     repoUrl,
-    false
+    disableLogging,
+    shallowClone
   );
   const shell = getDefaultShell();
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -119,14 +119,21 @@ function registerIpcForUpdateRemoteScreen() {
 
   // Listen to "clone repo" request and clone the repo based on data passed
   ipc.answerRenderer('clone-repo', async data => {
-    const { selectedProvider, username, repoUrl, selectedFolder } = data;
+    const {
+      selectedProvider,
+      username,
+      repoUrl,
+      selectedFolder,
+      shallowClone,
+    } = data;
 
     try {
       const { code, repoFolder } = await cloneRepo(
         selectedProvider,
         username,
         repoUrl,
-        selectedFolder
+        selectedFolder,
+        shallowClone
       );
 
       if (code === 0) {

--- a/src/renderer/components/Switch.js
+++ b/src/renderer/components/Switch.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Switch = ({ isOn, handleToggle, onColor }) => {
+const Switch = ({ isOn, handleToggle, activeColor = '#38a169' }) => {
   return (
     <>
       <input
@@ -11,7 +11,7 @@ const Switch = ({ isOn, handleToggle, onColor }) => {
         type="checkbox"
       />
       <label
-        style={{ background: isOn && onColor }}
+        style={{ background: isOn && activeColor }}
         className="react-switch-label"
         htmlFor="react-switch-new">
         <span className="react-switch-button" />

--- a/src/renderer/components/Switch.js
+++ b/src/renderer/components/Switch.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const Switch = ({ isOn, handleToggle, onColor }) => {
+  return (
+    <>
+      <input
+        checked={isOn}
+        onChange={handleToggle}
+        className="react-switch-checkbox"
+        id="react-switch-new"
+        type="checkbox"
+      />
+      <label
+        style={{ background: isOn && onColor }}
+        className="react-switch-label"
+        htmlFor="react-switch-new">
+        <span className="react-switch-button" />
+      </label>
+    </>
+  );
+};
+
+export default Switch;

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -240,7 +240,7 @@ export default function UpdateRemoteDirect() {
             isOn={shallowClone}
             handleToggle={() => setShallowClone(!shallowClone)}
           />
-          <span className="flex-1 ml-2 text-gray-600">Shallow Clone Repo?</span>
+          <span className="flex-1 ml-2 text-gray-600">Shallow Clone</span>
           <span
             className="flex-0 text-gray-600 hover:text-gray-700 text-sm underline cursor-pointer"
             onClick={openShallowCloneInfoUrl}>

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -5,6 +5,7 @@ import { history } from '../../App';
 // Components
 import Modal from '../../components/Modal';
 import Toolbar from '../../components/Toolbar';
+import Switch from '../../components/Switch';
 
 // Reducer
 import fetchReducer from '../../reducers/fetchReducer';
@@ -25,6 +26,8 @@ export default function UpdateRemoteDirect() {
 
   const [sshConfig, setSshConfig] = useState({}); // Stores config values coming from .ssh config file.
   const [noKeysSetupError, setNoKeysSetupError] = useState(false); // Stores state to determine whether to show ssh keys not setup error at top of dialog or not.
+
+  const [shallowClone, setShallowClone] = useState(false);
 
   // Custom hook to handle account options to select and render
   const [account, setAccount, AccountDropdown] = useDropdown(
@@ -115,6 +118,7 @@ export default function UpdateRemoteDirect() {
       username,
       repoUrl,
       selectedFolder,
+      shallowClone,
     });
     const { success, error, repoFolder } = result;
 
@@ -151,6 +155,7 @@ export default function UpdateRemoteDirect() {
     setRepoFolder('');
     setAccount('');
     setUsername('');
+    setShallowClone(false);
     dispatch({ type: 'FETCH_RESET' });
   }
 
@@ -172,6 +177,10 @@ export default function UpdateRemoteDirect() {
 
   function navigateToSshSetupScreen() {
     history.navigate('oauth/');
+  }
+
+  function openShallowCloneInfoUrl() {
+    // To be implemented.
   }
 
   // Render functions
@@ -211,7 +220,7 @@ export default function UpdateRemoteDirect() {
         <label className="text-gray-800 block text-left text-base mt-4 font-semibold">
           Choose Folder
         </label>
-        <div className="relative mb-6 mt-2">
+        <div className="relative mt-2">
           <input
             type="text"
             className="text-gray-800 text-base bg-gray-100 px-4 py-2 rounded border-2 w-full focus:outline-none"
@@ -224,6 +233,20 @@ export default function UpdateRemoteDirect() {
             onClick={onChangeDefaultFolderClicked}>
             Choose
           </button>
+        </div>
+        <div className="my-6 flex items-center">
+          <Switch
+            className="flex-1"
+            onColor={'#38a169'}
+            isOn={shallowClone}
+            handleToggle={() => setShallowClone(!shallowClone)}
+          />
+          <span className="flex-1 ml-2 text-gray-600">Shallow Clone Repo?</span>
+          <span
+            className="flex-0 text-gray-600 hover:text-gray-700 text-sm underline cursor-pointer"
+            onClick={openShallowCloneInfoUrl}>
+            What is shallow clone?
+          </span>
         </div>
         <button
           className={

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -237,7 +237,6 @@ export default function UpdateRemoteDirect() {
         <div className="my-6 flex items-center">
           <Switch
             className="flex-1"
-            onColor={'#38a169'}
             isOn={shallowClone}
             handleToggle={() => setShallowClone(!shallowClone)}
           />

--- a/src/renderer/pages/updateremote/UpdateRemoteStepped.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteStepped.js
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 
 import Modal from '../../components/Modal';
+import Switch from '../../components/Switch';
 
 import { openFolder } from '../../../lib/app-shell';
 
@@ -23,6 +24,8 @@ export default function UpdateRemoteStepped() {
   const [repoUrl, setRepoUrl] = useState(''); // Stores repourl entered by user
   const [selectedFolder, setSelectedFolder] = useState(''); // Stores parent folder that user selects where to "clone repo"
   const [repoFolder, setRepoFolder] = useState(''); // Stores repoFolder user selects for which they are updating "remote url"
+
+  const [shallowClone, setShallowClone] = useState(false); // Stores state whether to shallow clone based on user input
 
   const [{ isLoading, isError, data: success }, dispatch] = useReducer(
     fetchReducer,
@@ -66,9 +69,10 @@ export default function UpdateRemoteStepped() {
       username,
       repoUrl,
       selectedFolder,
+      shallowClone,
     });
-
     const { success, error, repoFolder } = result;
+
     if (success) {
       dispatch({ type: 'FETCH_SUCCESS', payload: { success: true } });
       setTimeout(() => openFolder(repoFolder), 1000);
@@ -101,6 +105,7 @@ export default function UpdateRemoteStepped() {
     setRepoUrl('');
     setSelectedFolder('');
     setRepoFolder('');
+    setShallowClone(false);
     dispatch({ type: 'FETCH_RESET' });
   }
 
@@ -110,6 +115,11 @@ export default function UpdateRemoteStepped() {
     setSelectedFolder('');
     dispatch({ type: 'FETCH_RESET' });
   }
+
+  function openShallowCloneInfoUrl() {
+    // To be implemented with proper openExternal link
+  }
+  // Render functions
 
   function renderCloneRepoDialog() {
     return (
@@ -131,7 +141,7 @@ export default function UpdateRemoteStepped() {
         <label className="text-gray-800 block text-left text-base mt-4 font-semibold">
           Choose Folder
         </label>
-        <div className="relative mb-6 mt-2">
+        <div className="relative mt-2">
           <input
             type="text"
             className="text-gray-800 text-base bg-gray-100 px-4 py-2 rounded border-2 w-full focus:outline-none"
@@ -143,6 +153,20 @@ export default function UpdateRemoteStepped() {
             onClick={onChangeDefaultFolderClicked}>
             Choose
           </button>
+        </div>
+        <div className="my-6 flex items-center">
+          <Switch
+            className="flex-1"
+            onColor={'#38a169'}
+            isOn={shallowClone}
+            handleToggle={() => setShallowClone(!shallowClone)}
+          />
+          <span className="flex-1 ml-2 text-gray-600">Shallow Clone Repo?</span>
+          <span
+            className="flex-0 text-gray-600 hover:text-gray-700 text-sm underline cursor-pointer"
+            onClick={openShallowCloneInfoUrl}>
+            What is shallow clone?
+          </span>
         </div>
         <button
           className={

--- a/src/renderer/pages/updateremote/UpdateRemoteStepped.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteStepped.js
@@ -157,7 +157,6 @@ export default function UpdateRemoteStepped() {
         <div className="my-6 flex items-center">
           <Switch
             className="flex-1"
-            onColor={'#38a169'}
             isOn={shallowClone}
             handleToggle={() => setShallowClone(!shallowClone)}
           />

--- a/src/renderer/pages/updateremote/UpdateRemoteStepped.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteStepped.js
@@ -160,7 +160,7 @@ export default function UpdateRemoteStepped() {
             isOn={shallowClone}
             handleToggle={() => setShallowClone(!shallowClone)}
           />
-          <span className="flex-1 ml-2 text-gray-600">Shallow Clone Repo?</span>
+          <span className="flex-1 ml-2 text-gray-600">Shallow Clone</span>
           <span
             className="flex-0 text-gray-600 hover:text-gray-700 text-sm underline cursor-pointer"
             onClick={openShallowCloneInfoUrl}>


### PR DESCRIPTION
- Added long pending shallow clone feature when cloning repo. 🎉
- Added it in both Direct and Stepped UpdateRemote screens. 
- Created iOS like Switch component in the process using custom css. Copied most of things(almost everything) from [this](https://upmostly.com/tutorials/build-a-react-switch-toggle-componen) article.
It is not reusable or scalable right now but that is fine consider we're not thinking about using it in multiple places in App right now.