### PR TITLE
Feat : Send Clone Repo Result Notificaitions

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -5,7 +5,10 @@
     "category": "public.app-category.developer-tools",
     "darkModeSupport": true,
     "target": "dmg",
-    "identity": null
+    "identity": null,
+    "extendInfo": {
+      "NSUserNotificationAlertStyle": "alert"
+    }
   },
   "win": {
     "target": "nsis"

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -15,6 +15,7 @@ const {
 
 // dialog wrapper
 const dialog = require('./dialog');
+const notification = require('./notification');
 
 let githubConfig = null; //workaround to store github config because electron-builder doesn't works with .env files.
 
@@ -137,6 +138,11 @@ function registerIpcForUpdateRemoteScreen() {
       );
 
       if (code === 0) {
+        notification.sendCloneRepoResultNotification(
+          (success = true),
+          (error = null),
+          repoFolder
+        );
         return {
           success: true,
           repoFolder,
@@ -144,6 +150,14 @@ function registerIpcForUpdateRemoteScreen() {
         };
       }
     } catch (error) {
+      notification.sendCloneRepoResultNotification(
+        (success = false),
+        (error = {
+          message: error.message
+            ? error.message
+            : 'Something went wrong when cloning repo',
+        })
+      );
       setTimeout(() =>
         dialog.showErrorDialog(
           error.message

--- a/src/main/notification.js
+++ b/src/main/notification.js
@@ -1,0 +1,49 @@
+const { Notification, shell } = require('electron');
+
+function sendCloneRepoResultNotification(success, error, repoFolder = null) {
+  if (Notification.isSupported) {
+    let toast;
+    let actions = [];
+
+    if (success) {
+      // MacOS only notification actions for showing button 'Open Folder' in notification
+      actions.push({
+        type: 'button',
+        text: 'Open Folder',
+      });
+
+      toast = createNotification(
+        (title = 'Clone Success!'),
+        (body = `Repo was cloned to ${repoFolder} folder`),
+        (actions = actions)
+      );
+
+      toast.on('click', _event => shell.openItem(repoFolder));
+      toast.on('action', (_event, _index) => shell.openItem(repoFolder));
+    } else {
+      toast = createNotification(
+        (title = 'Clone Error!'),
+        (body = error.message),
+        (actions = actions)
+      );
+    }
+
+    toast.show();
+  } else {
+    console.log('Notification not supported...');
+  }
+}
+
+function createNotification(title, body, actions = []) {
+  const notification = new Notification({
+    title,
+    body,
+    actions,
+  });
+
+  return notification;
+}
+
+module.exports = {
+  sendCloneRepoResultNotification,
+};

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -271,7 +271,8 @@ export default function UpdateRemoteDirect() {
         </button>
         {isLoading && (
           <p className="text-xs text-gray-600 mt-2">
-            This might take few seconds to minutes...
+            This might take few seconds to minutes...You will be notified once
+            the repo is cloned.
           </p>
         )}
       </div>

--- a/src/renderer/pages/updateremote/UpdateRemoteStepped.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteStepped.js
@@ -189,7 +189,8 @@ export default function UpdateRemoteStepped() {
         </button>
         {isLoading && (
           <p className="text-xs text-gray-600 mt-2">
-            This might take few seconds to minutes...
+            This might take few seconds to minutes...You will be notified once
+            the repo is cloned.
           </p>
         )}
       </div>


### PR DESCRIPTION
- Using Electron's Notification system to send desktop notifications for **Clone Repo** result(success and error). 
- Created `notification` module as central place where we setup and send notifications in App.
- Added following config to **electron-builder.json** file for having [NotificationActions](https://electronjs.org/docs/api/structures/notification-action) available only on MacOS to show button "Open Folder" in notification which helps convey that clicking on notification will open folder of the repo that was just cloned :

```
"extendInfo": {
  "NSUserNotificationAlertStyle": "alert"
}
```  
Note : The above config would only work when we sign the App.
