### PR TITLE
Added .env variables using Github secrets

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -29,10 +29,10 @@ jobs:
         run: yarn release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_CLIENT_ID: $${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: $${{ secrets.GITHUB_CLIENT_SECRET }}
-          BITBUCKET_CLIENT_ID: $${{ secrets.BITBUCKET_CLIENT_ID }}
-          GITLAB_CLIENT_ID: $${{ secrets.GITLAB_CLIENT_ID }}
+          GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          BITBUCKET_CLIENT_ID: ${{ secrets.BITBUCKET_CLIENT_ID }}
+          GITLAB_CLIENT_ID: ${{ secrets.GITLAB_CLIENT_ID }}
 
       - name: See dist dir
         run: ls ./dist
@@ -61,10 +61,10 @@ jobs:
         run: yarn release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_CLIENT_ID: $${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: $${{ secrets.GITHUB_CLIENT_SECRET }}
-          BITBUCKET_CLIENT_ID: $${{ secrets.BITBUCKET_CLIENT_ID }}
-          GITLAB_CLIENT_ID: $${{ secrets.GITLAB_CLIENT_ID }}
+          GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          BITBUCKET_CLIENT_ID: ${{ secrets.BITBUCKET_CLIENT_ID }}
+          GITLAB_CLIENT_ID: ${{ secrets.GITLAB_CLIENT_ID }}
 
       - name: See dist dir
         run: ls ./dist


### PR DESCRIPTION
We can also store `.env` file in some secure storage and copy it to our app folder using bash script before running our release job. But, considering that we've not many env/api keys to manage right now decided to read **env** variables from Github secrets directly.
 Much easier and secure option for now.