### PR TITLE
Filter falsy values to avoid false values in list of postcss plugins

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -7,5 +7,5 @@ module.exports = {
         content: ['./src/renderer/**/*.js', './public/index.html'],
         defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
       }),
-  ],
+  ].filter(Boolean),
 };


### PR DESCRIPTION
When `process.env.NODE_ENV !== production`(in dev) the false value was getting added in list of **PostCss** plugins, causing build process to fail.  So, we're filtering out falsy values on plugins array using `filter()` method.