### PR TITLE
Feat : Add custom app menu

### DIFF
--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -11,11 +11,6 @@ function renderLandingPage(navigateTo) {
       <RevealGlobalStyles />
       <div className="flex justify-between">
         <AlphaBadge className="z-10" />
-        <a
-          className="mt-2 mr-4 text-gray-400 hover:text-gray-100 text-base hover:underline cursor-pointer"
-          href="#">
-          Help
-        </a>
       </div>
       <div className="flex flex-col items-center pb-8">
         <Reveal delay={100}>
@@ -65,11 +60,6 @@ function renderHomePage(navigateTo) {
     <div className="bg-gray-300 h-screen">
       <div className="flex justify-between">
         <AlphaBadge className="z-10" />
-        <a
-          className="mt-2 mr-4 text-gray-800 hover:text-gray-900 text-base hover:underline cursor-pointer"
-          href="#">
-          Help
-        </a>
       </div>
       <div className="flex flex-col items-center pb-8">
         <img src={logo} className="w-20 h-20" />


### PR DESCRIPTION
- Add custom app menu. Used `Menu.buildFromTemplate()` to create custom menu.

> App menu(Mac only):
> - about app
> - changelog
> - rest of mac specific icons
> 
> File menu:
> - Close(for Mac)
> - Exit(for non-mac)
> 
> Edit menu:
> - All default ones like Copy, Paste and few Mac specific items
> 
> View menu:
> - Dev Tools(dev only)
> - Reload(dev only)
> - Force Reload(dev only)
> - Zoom in
> - Zoom out
> - Toggle Fullscreen
> 
> 
> Window menu:
> - Minimize
> - Zoom
> - Few mac specific items
> 
> Help menu:
> - Learn more(redirecting to our website)
> - Changelog(only for non-mac. Because we've already this thing in app menu in Mac).

-------------------------------

- Removed Help link from Home and Landing screen because we are already providing the same from menu items now.