### PR TITLE
Add global error handler using electron-unhandled

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@sentry/electron": "1.0.0",
     "axios": "^0.19.0",
     "electron-better-ipc": "^0.6.0",
+    "electron-unhandled": "^3.0.1",
     "layout-styled-components": "^0.1.11",
     "node-pty": "^0.8.1",
     "query-string": "^6.8.1",

--- a/src/lib/crash-reporter.js
+++ b/src/lib/crash-reporter.js
@@ -1,6 +1,9 @@
-const { init } = require('@sentry/electron');
+const { shell } = require('electron');
+const { init, captureException } = require('@sentry/electron');
+const unhandled = require('electron-unhandled');
 
 const { sentry } = require('./config');
+const { openNewGithubIssueUrl } = require('./util');
 const isDev = require('../lib/electron-is-dev');
 
 function initSentry() {
@@ -11,4 +14,24 @@ function initSentry() {
   }
 }
 
-module.exports = initSentry;
+function catchGlobalErrors() {
+  unhandled({
+    logger: error => {
+      captureException(error);
+    },
+    showDialog: true,
+    reportButton: error => {
+      const githubIssueUrl = openNewGithubIssueUrl({
+        user: 'punitda',
+        repo: 'ssh-git',
+        body: `\`\`\`\n${error.stack}\n\`\`\`\n\n`,
+      });
+      shell.openExternal(githubIssueUrl);
+    },
+  });
+}
+
+module.exports = {
+  initSentry,
+  catchGlobalErrors,
+};

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -326,6 +326,47 @@ function getDefaultShell() {
   return env.SHELL || '/bin/sh';
 }
 
+function openNewGithubIssueUrl(options = {}) {
+  let repoUrl;
+  if (options.repoUrl) {
+    repoUrl = options.repoUrl;
+  } else if (options.user && options.repo) {
+    repoUrl = `https://github.com/${options.user}/${options.repo}`;
+  } else {
+    throw new Error(
+      'You need to specify either the `repoUrl` option or both the `user` and `repo` options'
+    );
+  }
+
+  const url = new URL(`${repoUrl}/issues/new`);
+
+  const types = [
+    'body',
+    'title',
+    'labels',
+    'template',
+    'milestone',
+    'assignee',
+    'projects',
+  ];
+
+  for (const type of types) {
+    let value = options[type];
+    if (value === undefined) {
+      continue;
+    }
+
+    if (type === 'labels' || type === 'projects') {
+      if (!Array.isArray(value)) {
+        throw new TypeError(`The \`${type}\` option should be an array`);
+      }
+      value = value.join(',');
+    }
+    url.searchParams.set(type, value);
+  }
+  return url.toString();
+}
+
 module.exports = {
   getCommands,
   createSshConfig,
@@ -335,4 +376,5 @@ module.exports = {
   getCloneRepoCommand,
   getNewRemoteUrlAndAliasName,
   getDefaultShell,
+  openNewGithubIssueUrl,
 };

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,7 +4,7 @@ const window = require('./window');
 const helpers = require('./helpers');
 const ipc = require('./ipc');
 
-const initSentry = require('../lib/crash-reporter');
+const { initSentry, catchGlobalErrors } = require('../lib/crash-reporter');
 
 function init() {
   app.setName('ssh-git');
@@ -52,6 +52,7 @@ function init() {
   });
 
   initSentry();
+  catchGlobalErrors();
 }
 
 init(); // this is where it all starts

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,5 +1,6 @@
 window.ipc = require('electron-better-ipc').ipcRenderer; // Using electron-better-ipc for better ipc comm api.
 
-// Init sentry for renderer process
-const initSentry = require('../lib/crash-reporter');
+// Init sentry for renderer process and catch global errors on window
+const { initSentry, catchGlobalErrors } = require('../lib/crash-reporter');
 initSentry();
+catchGlobalErrors();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2533,6 +2533,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+clean-stack@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
 cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
@@ -3493,6 +3498,11 @@ electron-fetch@1.3.0:
   dependencies:
     encoding "^0.1.12"
 
+electron-is-dev@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.1.0.tgz#b15a2a600bdc48a51a857d460e05f15b19a2522c"
+  integrity sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ==
+
 electron-publish@21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-21.2.0.tgz#cc225cb46aa62e74b899f2f7299b396c9802387d"
@@ -3538,6 +3548,16 @@ electron-to-chromium@^1.3.191:
   version "1.3.191"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz#c451b422cd8b2eab84dedabab5abcae1eaefb6f0"
   integrity sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==
+
+electron-unhandled@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/electron-unhandled/-/electron-unhandled-3.0.1.tgz#34794326d850ac7bc1a1d2fe90f2b0fcd4d12c9c"
+  integrity sha512-eIK3LpT/1hrBK4dJjHEQLbTvI8XOflItCOtMzY2RIaRfGAXV0JfJoTe+Y59Q9b/87oXWmSD5p2Dnp2Nzgtlijg==
+  dependencies:
+    clean-stack "^2.1.0"
+    electron-is-dev "^1.0.1"
+    ensure-error "^2.0.0"
+    lodash.debounce "^4.0.8"
 
 electron@^5.0.7:
   version "5.0.7"
@@ -3589,6 +3609,11 @@ end-of-stream@^1.1.0:
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
   dependencies:
     once "^1.4.0"
+
+ensure-error@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ensure-error/-/ensure-error-2.0.0.tgz#b8359a992601601b3541af9472f6a49d9dca1458"
+  integrity sha512-1ela4oR5A+TdtFpfiQrZKFUbsOi4JuIYmz2qSGFar6pEdRa54E15mKHVVYrAq1OQhd6b6nVrCaQxQlo6kYwhaw==
 
 entities@^1.1.1:
   version "1.1.2"
@@ -5140,6 +5165,11 @@ lodash.clone@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
- Catching uncaught exceptions and errors in main and renderer process using `electron-unhandled`.
- Reporting errors to Sentry as well using `captureException()` method.
- Show Error dialog as well with option to report issue to Github.