### PR TITLE
Feat : Layout changes in Add Key screen

### DIFF
--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -17,7 +17,7 @@
 }
 
 .primary-btn:enabled {
-  @apply bg-blue-500;
+  @apply bg-blue-600;
 }
 
 .primary-btn:hover:enabled {
@@ -33,7 +33,7 @@
 }
 
 .primary-btn:disabled {
-  @apply bg-blue-400;
+  @apply bg-blue-500;
 }
 
 .secondary-btn {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -287,29 +287,23 @@ function replaceRemoteUrl(remoteUrl, selectedProvider, username) {
 
 const github_steps = [
   `Copy the Public Key you see on the right side to the clipboard`,
-  `Login in to your Github account`,
   `Open this `,
-  `Once you're on that page, paste the key you just copied under the "Key" input and
-  for "Title" input you can give it any value you prefer to identify the key in future. [E.x. Macbook Pro(Office)]`,
-  `Clone Repo or Update Remote url`,
+  `Paste the key you just copied under the "Key" input and
+  for "Title" input you can give it any value you prefer to identify the key in future.`,
 ];
 
 const bitbucket_steps = [
   `Copy the Public Key you see on the right side to the clipboard`,
-  `Login in to your Bitbucket account`,
   `Open this `,
-  `Once you're on that page, click on "Add key" button and paste the key you just copied under the "Key" input
-  and for "Label" input you can give it any value you prefer to identify the key in future. [E.x. Macbook Pro(Office)]`,
-  `Clone Repo or Update Remote url`,
+  `Click on "Add key" button and paste the key you just copied under the "Key" input
+  and for "Label" input you can give it any value you prefer to identify the key in future.`,
 ];
 
 const gitlab_steps = [
   `Copy the Public Key you see on the right side to the clipboard`,
-  `Login in to your Gitlab account`,
   `Open this `,
-  `Once you're on that page, paste the key you just copied under the "Key" input 
-  and for "Title" input you can give it any value you prefer to identify the key in future. [E.x. Macbook Pro(Office)]`,
-  `Clone Repo or Update Remote url`,
+  `Paste the key you just copied under the "Key" input 
+  and for "Title" input you can give it any value you prefer to identify the key in future.`,
 ];
 
 function getDefaultShell() {

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -23,14 +23,14 @@ function renderLandingPage(navigateTo) {
         </Reveal>
         <Reveal delay={300}>
           <h2 className="text-gray-200 text-2xl text-center tracking-wide">
-            Painlessly manage ssh keys for Github/Bitbucket/Gitlab
+            Painlessly manage ssh keys for Github, Bitbucket and Gitlab accounts
           </h2>
         </Reveal>
         <div className="mt-16 flex flex-row justify-between items-center ">
           {steps.map((step, index) => (
             <Reveal delay={400 + (index + 1) * 100}>
               <div className="w-48 h-48 mr-8 flex flex-col items-center bg-gray-700 rounded-lg shadow-lg">
-                <div className="w-8 h-8 mt-4 text-gray-900 text-xl text-center font-semibold bg-gray-100 rounded-full shadow">
+                <div className="w-8 h-8 mt-4 text-gray-700 text-xl text-center font-semibold bg-gray-100 rounded-full shadow">
                   {index + 1}
                 </div>
                 <h1 className="mt-2 px-4 text-xl text-center font-bold text-gray-300">

--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -9,7 +9,7 @@ import { providers } from '../../../lib/config';
 import { getManualSteps } from '../../../lib/util';
 
 function AddKey({ onNext }) {
-  const [authState, setAuthState] = useContext(AuthStateContext);
+  const [authState] = useContext(AuthStateContext);
   const {
     selectedProvider = null,
     bitbucket_uuid = null,
@@ -85,35 +85,23 @@ function AddKey({ onNext }) {
   }
 
   return (
-    <div>
+    <div class="max-w-full mx-auto flex flex-col items-center justify-center">
       <h2 className="mx-16 mt-8 text-2xl text-center text-gray-900">
-        To start using the generated ssh key, you need to add it to your
-        account.
+        Follow below steps to add generated key to your account
       </h2>
-      <div className="flex flex-row mt-8 items-center justify-start mx-16">
+      <div className="flex flex-row items-center justify-center mx-16 my-12">
         <div className="flex flex-col flex-1">
-          <h3 className="text-lg">Follow below steps:</h3>
-          <ul className="text-gray-800 pr-12 text-left mt-2 leading-relaxed">
+          <h3 className="text-xl">Steps:</h3>
+          <ul className="text-gray-700 text-lg pr-12 text-left mt-2 leading-relaxed">
             {getManualSteps(selectedProvider).map((step, index) => {
-              if (index === 2) {
+              if (index === 1) {
                 return (
                   <li key={index}>
                     {`${index + 1}. ${step}`}
                     <button
-                      className="underline hover:text-blue-500"
+                      className="underline hover:text-blue-700 hover:font-semibold"
                       onClick={openSettingsPage}>
                       Link
-                    </button>
-                  </li>
-                );
-              } else if (index === 4) {
-                return (
-                  <li key={index}>
-                    {`${index + 1}. `}
-                    <button
-                      className="underline text-blue-500 hover:text-blue-700"
-                      onClick={openNextPage}>
-                      {step}
                     </button>
                   </li>
                 );
@@ -123,7 +111,7 @@ function AddKey({ onNext }) {
             })}
           </ul>
         </div>
-        <div className="w-1/2">
+        <div className="flex-1">
           <h3 className="text-lg">Public Key</h3>
           <div className="relative">
             <button
@@ -142,6 +130,13 @@ function AddKey({ onNext }) {
           </div>
         </div>
       </div>
+      <button className="primary-btn mt-8" onClick={openNextPage}>
+        Clone Repo
+      </button>
+      <p className="text-gray-700 text-sm mt-1">
+        (Make sure you have followed the above steps otherwise SSH key generated
+        wouldn't work)
+      </p>
     </div>
   );
 }

--- a/src/renderer/pages/sshsetup/GenerateKey.js
+++ b/src/renderer/pages/sshsetup/GenerateKey.js
@@ -142,10 +142,7 @@ const GenerateKey = ({ onNext }) => {
   }
 
   return (
-    <div
-      className={`${
-        isLinux ? 'h-144' : 'h-128'
-      } w-96 my-20 bg-gray-100 flex flex-col justify-center items-center rounded-lg shadow-md mx-auto`}>
+    <div className="h-144 w-96 my-20 bg-gray-100 flex flex-col justify-center items-center rounded-lg shadow-md mx-auto">
       <SquareLoader
         loading={isLoading}
         size={48}

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -345,7 +345,7 @@ export default function UpdateRemoteDirect() {
           onModalClose={onCloneRepoModalClose}>
           {renderCloneRepoDialog()}
         </Modal>
-        <p className="mt-2">
+        <p className="text-gray-700 mt-2">
           (Use this if your cloning this repository first time on your system)
         </p>
         <p className="my-4">OR</p>
@@ -355,7 +355,7 @@ export default function UpdateRemoteDirect() {
           onModalClose={onUpdateRemoteUrlModalClose}>
           {renderUpdateRemoteUrlDialog()}
         </Modal>
-        <p className="mt-2">
+        <p className="text-gray-700 mt-2">
           (Use this if your already have repository on your system)
         </p>
       </div>

--- a/src/renderer/pages/updateremote/UpdateRemoteStepped.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteStepped.js
@@ -259,7 +259,7 @@ export default function UpdateRemoteStepped() {
           onModalClose={onCloneRepoModalClose}>
           {renderCloneRepoDialog()}
         </Modal>
-        <p className="mt-2">
+        <p className="text-gray-700 mt-2">
           (Use this if your cloning this repository first time on your system)
         </p>
         <p className="my-4 text-xl">OR</p>
@@ -269,7 +269,7 @@ export default function UpdateRemoteStepped() {
           onModalClose={onUpdateRemoteUrlModalClose}>
           {renderUpdateRemoteUrlDialog()}
         </Modal>
-        <p className="mt-2">
+        <p className="text-gray-700 mt-2">
           (Use this if your already have repository on your system)
         </p>
       </div>


### PR DESCRIPTION
Add Key screen changes:
- Changed layout of Add Key screen.
- Reduced unnecessary instructions in steps and made it short.
- Add clear CTA button at bottom in center instead of using link like earlier.

Other changes:
- Made primary button little darker along with all its mode like enabled, hover, focussed, etc.
- Changed Landing screen copy text to match our site's landing page copy.
- Hint text color changes in UpdateRemote screens
- Increase form height to h-144 for all platforms. It was h-128 in Mac and h-144 in Linux. Not sure why we did it like this but decided to keep it h-144 for all now.
