### PR TITLE
Fix : Auto update api

### DIFF
--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -21,8 +21,11 @@ function request(
       provider === providers.GITHUB
         ? 'application/vnd.github.v3+json, application/json'
         : 'application/json',
-    'Content-Type': 'application/json',
   };
+
+  if (method === 'POST' || method === 'PUT') {
+    headers['Content-Type'] = 'application/json';
+  }
 
   if (token) {
     if (provider === providers.GITHUB) {

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -30,11 +30,11 @@ async function initLinux() {
   try {
     const response = await request(
       UPDATE_BASE_URL,
-      `check-updates?version=${APP_VERSION}&platform=${process.platform}`,
+      `/check-updates?version=${APP_VERSION}&platform=${process.platform}`,
       'GET'
     );
-    if (response.statusCode === 200) {
-      const { version, url } = response;
+    if (response.status === 200) {
+      const { version, url } = response.data;
 
       const skippedVersions = store.get('skipVersions');
       if (!skippedVersions.includes(version)) {
@@ -45,7 +45,7 @@ async function initLinux() {
           shell.openExternal(url); // Open download url
         }
       }
-    } else if (response.statusCode === 204) {
+    } else if (response.status === 204) {
       console.log(`No new update available`);
     } else {
       console.log(`Unexpected status code received : ${response.statusCode}`);


### PR DESCRIPTION
- Send "Content-Type" in request headers only for PUT/POST requests.
- Fix property access code of status value from axios's response object.