### PR TITLE
Disable primary buttons on success state

### DIFF
--- a/src/renderer/pages/sshsetup/ConnectAccount.js
+++ b/src/renderer/pages/sshsetup/ConnectAccount.js
@@ -111,7 +111,7 @@ function ConnectAccount({ onNext }) {
               ? `primary-btn-success`
               : `primary-btn`
           }
-          disabled={selectedProvider === '' || isConnecting}>
+          disabled={selectedProvider === '' || isConnecting || data}>
           {isConnecting
             ? 'Connecting...'
             : isError

--- a/src/renderer/pages/sshsetup/GenerateKey.js
+++ b/src/renderer/pages/sshsetup/GenerateKey.js
@@ -230,7 +230,12 @@ const GenerateKey = ({ onNext }) => {
             ? `primary-btn-success`
             : `primary-btn`
         }
-        disabled={isLoading || isGeneratingKey || passphrase === ''}>
+        disabled={
+          isLoading ||
+          isGeneratingKey ||
+          passphrase === '' ||
+          generateKeySuccess
+        }>
         {isGeneratingKey
           ? 'Generating Keys...'
           : isGenerateKeyError


### PR DESCRIPTION
This is because success state is shown on primary button for few milliseconds and chances are high that users would click on it during that time re-triggering that entire flow on that step(screen) once again. Better we disable primary buttons during success state. I know not an ideal way to handle state in the app but works for our situation.

Done it in `ConnectAccount` and `GenerateKey` screen for now. We will add it in `AddKey` screen once we add ssh connection verification step. This wouldn't be required in final `Clone/Update` screen.