### PR TITLE
Add Question page links

### DIFF
--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -288,7 +288,7 @@ function AddKey({ onNext }) {
             className="mt-8 mb-4 text-center underline text-gray-600 hover:text-gray-700 text-sm cursor-pointer"
             onClick={() =>
               openExternal(
-                `${web_base_url}/#why_app_doesn't_adds_key_automatically?`
+                `${web_base_url}/questions/why-app-doesnt-add-keys-automatically`
               )
             }>
             Why app doesn't adds key automatically?

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -14,7 +14,8 @@ import fetchReducer from '../../reducers/fetchReducer';
 import useDropdown from '../../hooks/useDropdown';
 
 // Internal libs
-import { openFolder } from '../../../lib/app-shell';
+import { openFolder, openExternal } from '../../../lib/app-shell';
+import { web_base_url } from '../../../lib/config';
 
 export default function UpdateRemoteDirect() {
   const cloneRepoButtonRef = useRef(null); //Used in modal for focusing reason
@@ -179,10 +180,6 @@ export default function UpdateRemoteDirect() {
     history.navigate('oauth/');
   }
 
-  function openShallowCloneInfoUrl() {
-    // To be implemented.
-  }
-
   // Render functions
 
   function renderNoKeysSetupError() {
@@ -243,7 +240,9 @@ export default function UpdateRemoteDirect() {
           <span className="flex-1 ml-2 text-gray-600">Shallow Clone</span>
           <span
             className="flex-0 text-gray-600 hover:text-gray-700 text-sm underline cursor-pointer"
-            onClick={openShallowCloneInfoUrl}>
+            onClick={() =>
+              openExternal(`${web_base_url}/questions/what-is-shallow-clone`)
+            }>
             What is shallow clone?
           </span>
         </div>

--- a/src/renderer/pages/updateremote/UpdateRemoteStepped.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteStepped.js
@@ -9,7 +9,8 @@ import React, {
 import Modal from '../../components/Modal';
 import Switch from '../../components/Switch';
 
-import { openFolder } from '../../../lib/app-shell';
+import { openFolder, openExternal } from '../../../lib/app-shell';
+import { web_base_url } from '../../../lib/config';
 
 import fetchReducer from '../../reducers/fetchReducer';
 import { AuthStateContext } from '../../Context';
@@ -146,10 +147,6 @@ export default function UpdateRemoteStepped() {
     dispatch({ type: 'FETCH_RESET' });
   }
 
-  function openShallowCloneInfoUrl() {
-    // To be implemented with proper openExternal link
-  }
-
   function playBigAnimation() {
     if (bigAnimation !== null) {
       bigAnimation.play();
@@ -211,7 +208,9 @@ export default function UpdateRemoteStepped() {
           <span className="flex-1 ml-2 text-gray-600">Shallow Clone</span>
           <span
             className="flex-0 text-gray-600 hover:text-gray-700 text-sm underline cursor-pointer"
-            onClick={openShallowCloneInfoUrl}>
+            onClick={() =>
+              openExternal(`${web_base_url}/questions/what-is-shallow-clone`)
+            }>
             What is shallow clone?
           </span>
         </div>


### PR DESCRIPTION
- Add `what-is-shallow-clone` link in Clone repo dialogs
- Add `why-app-doesnt-add-keys-automatically` link to **questions** page directly in `AddKey` screen instead of taking to `Faq` section as done earlier.