### PR TITLE
Chore : Add GA for page and event tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-spring": "^8.0.27",
     "ssh-config": "^2.0.0-beta.1",
     "toasted-notes": "^3.2.0",
-    "uuid": "^3.3.2"
+    "universal-analytics": "^0.4.20",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/src/main/analytics.js
+++ b/src/main/analytics.js
@@ -1,0 +1,34 @@
+const ua = require('universal-analytics');
+const uuid = require('uuid/v4');
+const { TrackingIdStore: store } = require('./store');
+
+const packageVersion = require('../../package.json');
+
+let visitor;
+let appName = 'app.ssh-git';
+let appVersion = packageVersion.version;
+
+function initAnalytics() {
+  const userId = store.get('userId') || uuid();
+  visitor = ua('UA-155290096-1', userId);
+}
+
+function trackEvent(category, action) {
+  visitor
+    .event(category, action, error => {
+      if (error) console.error('error tracking event: ', error.message);
+    })
+    .send();
+}
+
+function trackScreen(screenName) {
+  visitor
+    .pageview(screenName, appName, appVersion, error => {
+      if (error) {
+        console.error('error tracking pageview: ', error.message);
+      }
+    })
+    .send();
+}
+
+module.exports = { initAnalytics, trackEvent, trackScreen };

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -8,6 +8,8 @@ const updater = require('./updater');
 const { initSentry, catchGlobalErrors } = require('../lib/crash-reporter');
 const isDev = require('../lib/electron-is-dev');
 
+const { initAnalytics } = require('./analytics');
+
 function init() {
   app.setName('ssh-git');
 
@@ -60,6 +62,8 @@ function init() {
   if (!isDev) {
     setTimeout(() => updater.init(), 10 * 1000);
   }
+
+  initAnalytics();
 }
 
 init(); // this is where it all starts

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -3,6 +3,8 @@ const os = require('os');
 const { shell } = require('electron');
 const { ipcMain: ipc } = require('electron-better-ipc');
 
+const { trackScreen, trackEvent } = require('./analytics');
+
 // core methods
 const {
   generateKey,
@@ -26,6 +28,7 @@ function register() {
   registerIpcForGenerateKeyScreen();
   registerIpcForAddKeyScreen();
   registerIpcForUpdateRemoteScreen();
+  registerIpcForAnalytics();
 }
 
 function registerGeneralIpcs() {
@@ -225,6 +228,19 @@ function registerIpcForUpdateRemoteScreen() {
         success: false,
       };
     }
+  });
+}
+
+function registerIpcForAnalytics() {
+  ipc.answerRenderer(
+    'track-screen',
+    async ({ screenName, appName, appVersion }) => {
+      trackScreen(screenName, appName, appVersion);
+    }
+  );
+
+  ipc.answerRenderer('track-event', async ({ category, action }) => {
+    trackEvent(category, action);
   });
 }
 

--- a/src/main/store.js
+++ b/src/main/store.js
@@ -1,9 +1,16 @@
 const Store = require('electron-store');
+const uuid = require('uuid/v4');
 
-const store = new Store({
+const VersionStore = new Store({
   defaults: {
     skipVersions: [],
   },
 });
 
-module.exports = store;
+const TrackingIdStore = new Store({
+  defaults: {
+    userId: uuid(),
+  },
+});
+
+module.exports = { VersionStore, TrackingIdStore };

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -2,7 +2,7 @@ const { autoUpdater, shell } = require('electron');
 
 const { web_base_url } = require('../lib/config');
 
-const store = require('./store');
+const { VersionStore: store } = require('./store');
 const { createNotification } = require('./notification');
 const dialog = require('./dialog');
 

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -13,10 +13,19 @@ import UpdateRemoteDirect from './pages/updateremote/UpdateRemoteDirect';
 
 //Global app wide context to store user state.
 import { AuthStateContext } from './Context';
+import { trackScreen } from './analytics';
 
 //In-Memory Router
 const source = createMemorySource('/');
 export const history = createHistory(source);
+
+history.listen(({ location }) => {
+  if (location.pathname === '' || location.pathname === '/') {
+    trackScreen('main-screen');
+  } else {
+    trackScreen(location.pathname);
+  }
+});
 
 //Github token workaround.
 import { oauth } from '../lib/config';
@@ -43,7 +52,7 @@ function App() {
         <Router>
           <Home path="/" navigateTo={navigateTo} />
           <SSHSetup path="/oauth/*" />
-          <UpdateRemoteDirect path="/updateRemote" />
+          <UpdateRemoteDirect path="/updateRemoteDirect" />
         </Router>
       </LocationProvider>
     </AuthStateContext.Provider>

--- a/src/renderer/analytics.js
+++ b/src/renderer/analytics.js
@@ -1,0 +1,16 @@
+import package from '../../package.json';
+
+const appName = 'app.ssh-git';
+const appVersion = package.version;
+
+export async function trackScreen(screenName) {
+  await window.ipc.callMain('track-screen', {
+    screenName,
+    appName,
+    appVersion,
+  });
+}
+
+export async function trackEvent(category, action) {
+  await window.ipc.callMain('track-event', { category, action });
+}

--- a/src/renderer/analytics.js
+++ b/src/renderer/analytics.js
@@ -4,13 +4,21 @@ const appName = 'app.ssh-git';
 const appVersion = package.version;
 
 export async function trackScreen(screenName) {
-  await window.ipc.callMain('track-screen', {
-    screenName,
-    appName,
-    appVersion,
-  });
+  try {
+    await window.ipc.callMain('track-screen', {
+      screenName,
+      appName,
+      appVersion,
+    });
+  } catch (error) {
+    console.error('error tracking screen view');
+  }
 }
 
 export async function trackEvent(category, action) {
-  await window.ipc.callMain('track-event', { category, action });
+  try {
+    await window.ipc.callMain('track-event', { category, action });
+  } catch (error) {
+    console.error('error tracking event');
+  }
 }

--- a/src/renderer/components/Modal.js
+++ b/src/renderer/components/Modal.js
@@ -9,6 +9,7 @@ function Modal({
   ariaLabel,
   children,
   onModalClose,
+  onModalOpen,
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -24,6 +25,7 @@ function Modal({
 
   function onOpen() {
     setIsOpen(true);
+    onModalOpen();
   }
 
   function onClose() {

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -4,11 +4,11 @@ import AlphaBadge from '../../assets/img/alpha_badge.svg';
 import logo from '../../assets/logo/icon.png';
 
 import { Reveal, RevealGlobalStyles, Animation } from 'react-genie';
-import { trackScreen } from '../analytics';
+import { trackScreen, trackEvent } from '../analytics';
 
 function renderLandingPage(navigateTo) {
   React.useEffect(() => {
-    trackScreen('landing');
+    trackScreen('landing-screen');
   }, []);
 
   return (
@@ -51,7 +51,10 @@ function renderLandingPage(navigateTo) {
         <Reveal delay={1000} animation={Animation.SlideInRight}>
           <button
             className="w-48 px-4 py-2 mt-12 text-white text-xl font-semibold bg-blue-500 hover:bg-blue-700 rounded focus:outline-none"
-            onClick={_e => navigateTo('/oauth/connect')}>
+            onClick={_e => {
+              navigateTo('/oauth/connect');
+              trackEvent('splash', 'setup-ssh');
+            }}>
             Get Started
           </button>
         </Reveal>
@@ -73,13 +76,17 @@ function renderHomePage(navigateTo) {
         </h1>
         <button
           className="primary-btn w-56 mt-16"
-          onClick={_e => navigateTo('/oauth/connect')}>
+          onClick={_e => {
+            navigateTo('/oauth/connect');
+            trackEvent('splash', 'setup-ssh');
+          }}>
           Setup SSH
         </button>
         <button
           className="secondary-btn text-gray-300 w-56 mt-8"
           onClick={_e => {
             navigateTo('/updateRemoteDirect');
+            trackEvent('splash', 'clone-or-update');
           }}>
           Clone or Update
         </button>

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -4,8 +4,13 @@ import AlphaBadge from '../../assets/img/alpha_badge.svg';
 import logo from '../../assets/logo/icon.png';
 
 import { Reveal, RevealGlobalStyles, Animation } from 'react-genie';
+import { trackScreen } from '../analytics';
 
 function renderLandingPage(navigateTo) {
+  React.useEffect(() => {
+    trackScreen('landing');
+  }, []);
+
   return (
     <div className="bg-gray-800 h-screen">
       <RevealGlobalStyles />
@@ -46,7 +51,7 @@ function renderLandingPage(navigateTo) {
         <Reveal delay={1000} animation={Animation.SlideInRight}>
           <button
             className="w-48 px-4 py-2 mt-12 text-white text-xl font-semibold bg-blue-500 hover:bg-blue-700 rounded focus:outline-none"
-            onClick={_e => navigateTo('/oauth')}>
+            onClick={_e => navigateTo('/oauth/connect')}>
             Get Started
           </button>
         </Reveal>
@@ -68,12 +73,14 @@ function renderHomePage(navigateTo) {
         </h1>
         <button
           className="primary-btn w-56 mt-16"
-          onClick={_e => navigateTo('/oauth')}>
+          onClick={_e => navigateTo('/oauth/connect')}>
           Setup SSH
         </button>
         <button
           className="secondary-btn text-gray-300 w-56 mt-8"
-          onClick={_e => navigateTo('/updateRemote')}>
+          onClick={_e => {
+            navigateTo('/updateRemoteDirect');
+          }}>
           Clone or Update
         </button>
       </div>

--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -14,6 +14,7 @@ import ConfirmationModal from '../../components/ConfirmationModal';
 
 import checkMarkAnimationData from '../../../assets/lottie/checkmark.json';
 import useLottieAnimation from '../../hooks/useLottieAnimation';
+import { trackEvent } from '../../analytics';
 
 function AddKey({ onNext }) {
   const [authState] = useContext(AuthStateContext);
@@ -117,6 +118,7 @@ function AddKey({ onNext }) {
     if (keyCopied && linkOpened) {
       setError(null);
       openNextPage();
+      trackEvent('setup-flow', 'key-added');
     }
   }
 
@@ -150,6 +152,8 @@ function AddKey({ onNext }) {
         keyCopyAnimation.play();
       }
     }, 1500);
+
+    trackEvent('setup-flow', 'key-copied');
   }
 
   function onLinkOpened(event) {
@@ -162,6 +166,8 @@ function AddKey({ onNext }) {
     if (linkOpenAnimation !== null) {
       linkOpenAnimation.play();
     }
+
+    trackEvent('setup-flow', 'link-opened');
   }
 
   // Add listener for textarea change event which we don't allow to change to keep

--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -97,7 +97,7 @@ function AddKey({ onNext }) {
 
   // Open next screen using url link
   function openNextPage() {
-    onNext('oauth/updateRemote');
+    onNext('oauth/clone');
   }
 
   // Click listeners

--- a/src/renderer/pages/sshsetup/ConnectAccount.js
+++ b/src/renderer/pages/sshsetup/ConnectAccount.js
@@ -15,6 +15,8 @@ import githublogo from '../../../assets/img/github_logo.png';
 import bitbucketlogo from '../../../assets/img/bitbucket_logo.png';
 import gitlablogo from '../../../assets/img/gitlab_logo.png';
 
+import { trackEvent } from '../../analytics';
+
 function ConnectAccount({ onNext }) {
   // Using context to access Auth store
   const [authState, setAuthState] = useContext(AuthStateContext);
@@ -46,10 +48,12 @@ function ConnectAccount({ onNext }) {
             payload: { accountConnected: true },
           });
           setTimeout(() => onNext('oauth/generate'), 1500);
+          trackEvent('setup-flow', `${selectedProvider}-connect-success`);
 
           return true;
         } else {
           dispatch({ type: 'FETCH_ERROR' });
+          trackEvent('setup-flow', `${selectedProvider}-connect-error`);
           return false;
         }
       });
@@ -72,6 +76,7 @@ function ConnectAccount({ onNext }) {
       selectedProvider,
     }));
     openExternal(url);
+    trackEvent('setup-flow', `${selectedProvider}-connect`);
   }
 
   return (

--- a/src/renderer/pages/sshsetup/GenerateKey.js
+++ b/src/renderer/pages/sshsetup/GenerateKey.js
@@ -9,6 +9,8 @@ import fetchReducer from '../../reducers/fetchReducer';
 // Images and Loaders
 import SquareLoader from 'react-spinners/SquareLoader';
 
+import { trackEvent } from '../../analytics';
+
 const GenerateKey = ({ onNext }) => {
   const [authState, setAuthState] = useContext(AuthStateContext);
   const { token = null, selectedProvider = null } = authState;
@@ -93,7 +95,12 @@ const GenerateKey = ({ onNext }) => {
         selectedProvider,
         username,
       });
-      if (!overrideKeys) return;
+      if (!overrideKeys) {
+        trackEvent('setup-flow', 'override-key-false');
+        return;
+      } else {
+        trackEvent('setup-flow', 'override-key-true');
+      }
     }
 
     // All good, please generate key now.
@@ -105,6 +112,7 @@ const GenerateKey = ({ onNext }) => {
       overrideKeys,
     };
     generateKey(config);
+    trackEvent('setup-flow', 'generate-key');
   }
 
   // Email change handlder - required in cases we don't receive email address for user from apis.

--- a/src/renderer/pages/sshsetup/GenerateKey.js
+++ b/src/renderer/pages/sshsetup/GenerateKey.js
@@ -134,7 +134,7 @@ const GenerateKey = ({ onNext }) => {
 
     if (success) {
       dispatch({ type: 'FETCH_SUCCESS', payload: { keyGenerated: true } });
-      setTimeout(() => onNext('oauth/addKeys'), 1500);
+      setTimeout(() => onNext('oauth/add'), 1500);
     } else if (error) {
       dispatch({ type: 'FETCH_ERROR' });
     }

--- a/src/renderer/pages/sshsetup/SSHSetup.js
+++ b/src/renderer/pages/sshsetup/SSHSetup.js
@@ -9,7 +9,7 @@ import StepsNavBar from '../../components/StepsNavBar';
 //Pages
 import ConnectAccount from './ConnectAccount';
 import GenerateKey from './GenerateKey';
-import AddKeys from './AddKey';
+import AddKey from './AddKey';
 import UpdateRemoteStepped from '../updateremote/UpdateRemoteStepped';
 
 //Internal
@@ -20,21 +20,22 @@ const steps = ['Connect', 'Generate', 'Add', 'Clone'];
 export default function SSHSetup() {
   const [activeStepIndex, setActiveStepIndex] = useState(0);
   function goBackToHomeScreen() {
-    history.navigate('');
+    history.navigate('/');
   }
 
   function onNext(path) {
     switch (path) {
       case 'oauth/success':
+      case 'oauth/connect':
         setActiveStepIndex(0);
         break;
       case 'oauth/generate':
         setActiveStepIndex(1);
         break;
-      case 'oauth/addKeys':
+      case 'oauth/add':
         setActiveStepIndex(2);
         break;
-      case 'oauth/updateRemote':
+      case 'oauth/clone':
         setActiveStepIndex(3);
         break;
       default:
@@ -48,10 +49,10 @@ export default function SSHSetup() {
       <Toolbar onBackPressed={goBackToHomeScreen} title="Setup SSH" />
       <StepsNavBar steps={steps} activeIndex={activeStepIndex} />
       <Router>
-        <ConnectAccount path="/" onNext={onNext} />
+        <ConnectAccount path="/connect" onNext={onNext} />
         <GenerateKey path="/generate" onNext={onNext} />
-        <AddKeys path="/addKeys" onNext={onNext} />
-        <UpdateRemoteStepped path="/updateRemote" />
+        <AddKey path="/add" onNext={onNext} />
+        <UpdateRemoteStepped path="/clone" />
       </Router>
     </div>
   );

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -16,6 +16,7 @@ import useDropdown from '../../hooks/useDropdown';
 // Internal libs
 import { openFolder, openExternal } from '../../../lib/app-shell';
 import { web_base_url } from '../../../lib/config';
+import { trackEvent } from '../../analytics';
 
 export default function UpdateRemoteDirect() {
   const cloneRepoButtonRef = useRef(null); //Used in modal for focusing reason
@@ -126,8 +127,10 @@ export default function UpdateRemoteDirect() {
     if (success) {
       dispatch({ type: 'FETCH_SUCCESS', payload: { success: true } });
       setTimeout(() => openFolder(repoFolder), 1000);
+      trackEvent('clone-update-direct', 'clone-repo-success');
     } else {
       dispatch({ type: 'FETCH_ERROR' });
+      trackEvent('clone-update-direct', 'clone-repo-error');
     }
   }
 
@@ -144,9 +147,16 @@ export default function UpdateRemoteDirect() {
 
     if (success) {
       dispatch({ type: 'FETCH_SUCCESS', payload: { success: true } });
+      trackEvent('clone-update-direct', 'update-remote-success');
     } else {
       dispatch({ type: 'FETCH_ERROR' });
+      trackEvent('clone-update-direct', 'update-remote-error');
     }
+  }
+
+  // Listen to onOpen event of Modal component for tracking event
+  function onCloneRepoModalOpen() {
+    trackEvent('clone-update-direct', 'clone-repo-dialog-opened');
   }
 
   // Listen to onClose events of Modal component to reset local state.
@@ -158,6 +168,12 @@ export default function UpdateRemoteDirect() {
     setUsername('');
     setShallowClone(false);
     dispatch({ type: 'FETCH_RESET' });
+    trackEvent('clone-update-direct', 'clone-repo-dialog-closed');
+  }
+
+  // Listen to onOpen event of Modal component for tracking event
+  function onUpdateRemoteUrlModalOpen() {
+    trackEvent('clone-update-direct', 'update-remote-dialog-opened');
   }
 
   // Listen to onClose event of Update Remote Url Modal component
@@ -168,6 +184,7 @@ export default function UpdateRemoteDirect() {
     setAccount('');
     setUsername('');
     dispatch({ type: 'FETCH_RESET' });
+    trackEvent('clone-update-direct', 'update-remote-dialog-closed');
   }
 
   // Navigation methods
@@ -341,7 +358,8 @@ export default function UpdateRemoteDirect() {
         <Modal
           {...cloneRepoModalProps}
           buttonRef={cloneRepoButtonRef}
-          onModalClose={onCloneRepoModalClose}>
+          onModalClose={onCloneRepoModalClose}
+          onModalOpen={onCloneRepoModalOpen}>
           {renderCloneRepoDialog()}
         </Modal>
         <p className="text-gray-700 text-xs mt-2">
@@ -351,7 +369,8 @@ export default function UpdateRemoteDirect() {
         <Modal
           {...updateRepoModalProps}
           buttonRef={updateRemoteUrlButtonRef}
-          onModalClose={onUpdateRemoteUrlModalClose}>
+          onModalClose={onUpdateRemoteUrlModalClose}
+          onModalOpen={onUpdateRemoteUrlModalOpen}>
           {renderUpdateRemoteUrlDialog()}
         </Modal>
         <p className="text-gray-700 text-xs mt-2">

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -177,7 +177,7 @@ export default function UpdateRemoteDirect() {
   }
 
   function navigateToSshSetupScreen() {
-    history.navigate('oauth/');
+    history.navigate('oauth/connect');
   }
 
   // Render functions

--- a/src/renderer/pages/updateremote/UpdateRemoteStepped.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteStepped.js
@@ -27,6 +27,8 @@ import useWindowSize from '../../hooks/useWindowSize';
 // Reveal animation
 import { Reveal, RevealGlobalStyles } from 'react-genie';
 
+import { trackEvent } from '../../analytics';
+
 export default function UpdateRemoteStepped() {
   const [authState] = useContext(AuthStateContext);
   const { username = null, selectedProvider = null } = authState;
@@ -107,8 +109,10 @@ export default function UpdateRemoteStepped() {
     if (success) {
       dispatch({ type: 'FETCH_SUCCESS', payload: { success: true } });
       setTimeout(() => openFolder(repoFolder), 1000);
+      trackEvent('setup-flow', 'clone-repo-success');
     } else {
       dispatch({ type: 'FETCH_ERROR' });
+      trackEvent('setup-flow', 'clone-repo-error');
     }
   }
 
@@ -126,9 +130,16 @@ export default function UpdateRemoteStepped() {
 
     if (success) {
       dispatch({ type: 'FETCH_SUCCESS', payload: { success: true } });
+      trackEvent('setup-flow', 'update-remote-success');
     } else {
       dispatch({ type: 'FETCH_ERROR' });
+      trackEvent('setup-flow', 'update-remote-error');
     }
+  }
+
+  // Listen to onOpen event of Modal component for tracking event
+  function onCloneRepoModalOpen() {
+    trackEvent('setup-flow', 'clone-repo-dialog-opened');
   }
 
   // Listen to onClose event of Modal component to reset local state for "Clone Repo" Modal.
@@ -138,6 +149,12 @@ export default function UpdateRemoteStepped() {
     setRepoFolder('');
     setShallowClone(false);
     dispatch({ type: 'FETCH_RESET' });
+    trackEvent('setup-flow', 'clone-repo-dialog-closed');
+  }
+
+  // Listen to onOpen event of Modal component for tracking event
+  function onUpdateRemoteUrlModalOpen() {
+    trackEvent('setup-flow', 'update-remote-dialog-opened');
   }
 
   // Listen to onClose event of Modal component to reset local state for "Update Remote Url" Modal.
@@ -145,6 +162,7 @@ export default function UpdateRemoteStepped() {
     setRepoFolder('');
     setSelectedFolder('');
     dispatch({ type: 'FETCH_RESET' });
+    trackEvent('setup-flow', 'update-remote-dialog-closed');
   }
 
   function playBigAnimation() {
@@ -321,7 +339,8 @@ export default function UpdateRemoteStepped() {
           <Modal
             {...cloneRepoModalProps}
             buttonRef={cloneRepoButtonRef}
-            onModalClose={onCloneRepoModalClose}>
+            onModalClose={onCloneRepoModalClose}
+            onModalOpen={onCloneRepoModalOpen}>
             {renderCloneRepoDialog()}
           </Modal>
           <p className="text-gray-700 text-xs mt-2">
@@ -331,7 +350,8 @@ export default function UpdateRemoteStepped() {
           <Modal
             {...updateRepoModalProps}
             buttonRef={updateRemoteUrlButtonRef}
-            onModalClose={onUpdateRemoteUrlModalClose}>
+            onModalClose={onUpdateRemoteUrlModalClose}
+            onModalOpen={onUpdateRemoteUrlModalOpen}>
             {renderUpdateRemoteUrlDialog()}
           </Modal>
           <p className="text-gray-700 text-xs mt-2">

--- a/yarn.lock
+++ b/yarn.lock
@@ -9002,6 +9002,15 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
+universal-analytics@^0.4.20:
+  version "0.4.20"
+  resolved "https://registry.yarnpkg.com/universal-analytics/-/universal-analytics-0.4.20.tgz#d6b64e5312bf74f7c368e3024a922135dbf24b03"
+  integrity sha512-gE91dtMvNkjO+kWsPstHRtSwHXz0l2axqptGYp5ceg4MsuurloM0PU3pdOfpb5zBXUvyjT4PwhWK2m39uczZuw==
+  dependencies:
+    debug "^3.0.0"
+    request "^2.88.0"
+    uuid "^3.0.0"
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -9106,6 +9115,11 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
+
+uuid@^3.0.0, uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
- Using [universal-analytics](https://github.com/peaksandpies/universal-analytics/) to track events using Google Analytics and Measurement protocol behind the scene. Works in both main and renderer process of electron app. However, due to the way we've configured things with related to Parcel we have to send tracking events and page views from renderer processes using ipc and main process takes care of actually logging events and page views. Created analytics file both in main and renderer process for the same. 
- Using `uuid/v4` to generated unique **userId** for GA tracking purposes. Storing this **userId** in store using `electron-store` package so that it is persisted to disk and stays the same making it easier to track unique users easily.
- Added pageview tracking by listening to **history** source in `Reach Router's` api in `App.js`. Whenever path changes `history.listen()` method callback is triggered with new location object. Fetching `pathname` from it like following and leveraging that to track page views easily:

```javascript
history.listen(({ location }) => {
  if (location.pathname === '' || location.pathname === '/') {
    trackScreen('main-screen');
  } else {
    trackScreen(location.pathname);
  }
});
```
- Added critical event tracking events in App and divided those into 2 major categories :
        1. `setup-flow`
        2. `update-clone-direct`