### PR TITLE
Feat : Passphrase Toast Notification in Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ssh-git",
   "productName": "ssh-git",
   "version": "0.0.1",
-  "description": "Electron app used to generate, add and manage ssh keys for using git with dev platforms like Github/Bitbucket/Gitlab, etc.",
+  "description": "App used to manage ssh keys for Github, Bitbucket and Gitlab accounts",
   "repository": "https://github.com/punitda/ssh-git.git",
   "author": "punitdama <punitdama@gmail.com>",
   "main": "src/main/index.js",

--- a/src/renderer/hooks/useRequestUserProfile.js
+++ b/src/renderer/hooks/useRequestUserProfile.js
@@ -69,7 +69,7 @@ export default function useRequestUserProfile(selectedProvider, token) {
         }
       } catch (error) {
         if (!didCancel) {
-          dispatch({ type: 'FETCH_FAILURE' });
+          dispatch({ type: 'FETCH_ERROR' });
         }
       }
     }


### PR DESCRIPTION
- Showing Toast notification to users in **Linux** asking them to remember the ssh key passphrase they're entering which is needed after system restarts.
- Added some state logic to make sure the notification is shown only once the user starts typing passphrase. Plus, added effect to remove notification on component unmount as well.
- Fixed Action type dispatched in `useRequestProfile` hook on error. `FETCH_FAILURE` -> `FETCH_ERROR`.
- Fix description in `package.json` because same is used by **Ubuntu** to show description of the App. And, last used description one was not correct enough. 