### PR TITLE
Bug : Remove access_token flow for GitHub workaround

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -36,7 +36,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
           BITBUCKET_CLIENT_ID: ${{ secrets.BITBUCKET_CLIENT_ID }}
           GITLAB_CLIENT_ID: ${{ secrets.GITLAB_CLIENT_ID }}
 
@@ -68,7 +67,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
           BITBUCKET_CLIENT_ID: ${{ secrets.BITBUCKET_CLIENT_ID }}
           GITLAB_CLIENT_ID: ${{ secrets.GITLAB_CLIENT_ID }}
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@reach/router": "^1.2.1",
     "@sentry/electron": "1.0.0",
     "axios": "^0.19.0",
-    "electron-better-ipc": "^0.6.0",
+    "electron-better-ipc": "^0.7.0",
     "electron-store": "^5.1.0",
     "electron-unhandled": "^3.0.1",
     "layout-styled-components": "^0.1.11",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,9 +1,8 @@
 const oauth = {
   github: {
     client_id: process.env.GITHUB_CLIENT_ID,
-    client_secret: process.env.GITHUB_CLIENT_SECRET,
     scopes: {
-      basic: 'user',
+      basic: 'read:user,user:email',
     },
   },
   bitbucket: {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -52,7 +52,7 @@ function init() {
   // MacOS only(for handling deeplinks)
   app.on('open-url', (event, url) => {
     event.preventDefault();
-    helpers.handleAppURL(url, window.getMainWindow(), ipc.getGithubConfig());
+    helpers.handleAppURL(url, window.getMainWindow());
   });
 
   initSentry();

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -21,8 +21,6 @@ const notification = require('./notification');
 
 const isDev = require('../lib/electron-is-dev');
 
-let githubConfig = null; //workaround to store github config because electron-builder doesn't works with .env files.
-
 // Register for all ipc channel in the app over here once.
 function register() {
   registerGeneralIpcs();
@@ -43,13 +41,6 @@ function registerGeneralIpcs() {
   // Listen to request from renderer process to open folder
   ipc.answerRenderer('open-folder', async folderPath => {
     shell.openItem(folderPath);
-    return;
-  });
-
-  // Workaround to store github config coming in from our renderer process :(
-  // We can get rid of this workaround once we use Parcel for bundling electron process as well.
-  ipc.answerRenderer('github-config', async config => {
-    githubConfig = config;
     return;
   });
 }
@@ -246,8 +237,4 @@ function registerIpcForAnalytics() {
   });
 }
 
-function getGithubConfig() {
-  return githubConfig;
-}
-
-module.exports = { register, getGithubConfig };
+module.exports = { register };

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   Router,
   createMemorySource,
@@ -34,13 +34,6 @@ function App() {
   const state = useState({
     authState: { state: '', token: '', selectedProvider: '' },
   });
-
-  useEffect(() => {
-    async function sendGithubConfig() {
-      const _result = await window.ipc.callMain('github-config', oauth.github);
-    }
-    sendGithubConfig();
-  }, []);
 
   function navigateTo(path) {
     history.navigate(path);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4006,10 +4006,10 @@ ejs@^2.7.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.1.tgz#5b5ab57f718b79d4aca9254457afecd36fa80228"
   integrity sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==
 
-electron-better-ipc@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/electron-better-ipc/-/electron-better-ipc-0.6.0.tgz#fb4828aad9e0031dfb8a7d3e157ee246fe10cd23"
-  integrity sha512-rgPgF+tTkgKay1Xfl75L1LsEL+xftq+9q/fMOuKXmqZythTaMNnEWPbGfEAGqksTjwlr+hNXmEi3im4wEnDEuA==
+electron-better-ipc@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/electron-better-ipc/-/electron-better-ipc-0.7.0.tgz#da6c439933639954a889fe6109767c6aeaafca94"
+  integrity sha512-9gQOHoedFRdM/dQjKARTdxnTmdk/srecn0Ez89NOl8EsGwrpfKDQ4aN8mG6gFlgKL7SGFHZpeDBY+aiNh4+ECw==
   dependencies:
     serialize-error "^5.0.0"
 


### PR DESCRIPTION
- Github doesn't support Implicit Grant Flow for Oauth. So, as workaround till now we're were using Github's `CLIENT_SECRET` on client side and were using Github's api to exchange `access_token` for `code` value received in callback uri after user grants authorization to your app. 
Using client_secret on client side doesn't looks like right choice to me. So, created an api in the backend which accepts `code` value that client can send and respond back with `access_token` after getting it from Github's `accces_token` api endpoint. 

- Drop Ipc workaround as well which we implemented earlier for passing Github config from **renderer** process to **main** process. Not proud of it since the day i implemented it.🙈

- Along with these changes, reduce the Oauth scope we're asking for Github as well. Prior to it app was asking for **"user"** scope which also grants write access to user's profile which is not intended by App. So, we better narrow scope to what is needed to read user's basic information like email and username. Changed scope to **"read:user,user:email"**

- Rewrote `handleAppURL` logic for new access_token flow for Github.

- Removed GITHUB_CLIENT_SECRET env variable from Github Actions.

- Updated `electron-better-ipc` in the process because they recently added `ipc.callFocusedRenderer()` method which allows us to send event to focus window instead passing mainwindow object around unnecessarily.



