### PR TITLE
Fix: Update Remote Url not updated

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -378,7 +378,7 @@ If you have setup SSH keys using this App, we suggest you use clone feature and 
 
     const {
       newRemoteUrlAliasName,
-      newRemoteUrl,
+      updatedRemoteUrl: newRemoteUrl,
     } = await getNewRemoteUrlAndAliasName(fetchUrl, selectedProvider, username);
 
     if (newRemoteUrl && newRemoteUrlAliasName) {


### PR DESCRIPTION
- We're were using wrong name(**newRemoteUrl** instead of **updatedRemoteUrl**) when de-structuring results obtained from `getNewRemoteUrlAndAliasName()` method. Didn't think much about renaming variables in methods around update remote url code for now. Just renamed variable when de-structuring for now. 