### PR TITLE
Fix : Auto update issue in  MacOS(Squirrel.Mac)

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -4,7 +4,7 @@
   "mac": {
     "category": "public.app-category.developer-tools",
     "icon": "logo/icon.icns",
-    "target": "dmg",
+    "target": ["dmg", "zip"],
     "hardenedRuntime": true,
     "gatekeeperAssess": false,
     "entitlements": "build/entitlements.mac.plist",


### PR DESCRIPTION
This is because as per Squirrel.Mac docs looks like the "url" to download should include **zip** file and not **.dmg** directly resulting into update error we're facing right now.

> Squirrel will request "url" with Accept: application/zip and only supports installing ZIP updates. If future update formats are supported their MIME type will be added to the Accept header so that your server can return the appropriate format.

Added one more target - "zip" to mac configuration in `electron-builder.json`. This fixes auto update issue we're facing with Squirrel.Mac autoupdate feature.