### PR TITLE
Fix : No .ssh directory exists

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,9 +1,14 @@
 const { providers } = require('../lib/config');
 const path = require('path');
 const os = require('os');
+const fs = require('fs');
 
 function getCommands(config) {
-  const rsaFilePath = path.join(os.homedir(), '.ssh', config.rsaFileName);
+  const sshDir = path.join(os.homedir(), '.ssh');
+  const rsaFilePath = path.join(sshDir, config.rsaFileName);
+
+  if (!fs.existsSync(sshDir)) fs.mkdirSync(sshDir); // Making sure we create ".ssh" directory if doesn't exists before proceeding to generate keys
+
   if (process.platform === 'darwin') {
     return [
       `ssh-keygen -t rsa -b 4096 -C "${config.email}" -f ${config.rsaFileName} -P ${config.passphrase}`,

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -20,9 +20,6 @@ const {
   chunksToLinesAsync,
 } = require('@rauschma/stringio');
 
-// dialog wrapper
-const dialog = require('./dialog');
-
 // utils
 const {
   getCommands,


### PR DESCRIPTION
For users who are setting up ssh keys for first time there are high chances that they might not have `.ssh` directory on their machine.
Added check to make sure `.ssh` directory exists before running any "generateKey" commands else create one using `fs.mkdirSync(sshDir)`.