### PR TITLE
Feat : Refactor Routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "@rauschma/stringio": "^1.4.0",
-    "@reach/router": "^1.2.1",
+    "@reach/router": "1.3.1",
     "@sentry/electron": "1.0.0",
     "axios": "^0.19.0",
     "electron-better-ipc": "^0.7.0",

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -8,8 +8,8 @@ import {
 
 //Pages
 import Home from './pages/Home';
+import Landing from './pages/Landing';
 import SSHSetup from './pages/sshsetup/SSHSetup';
-import UpdateRemoteDirect from './pages/updateremote/UpdateRemoteDirect';
 
 // MST
 import { observer } from 'mobx-react-lite';
@@ -20,9 +20,24 @@ import { onSnapshot } from 'mobx-state-tree';
 import { trackScreen } from './analytics';
 
 //In-Memory Router
-const source = createMemorySource('/');
-export const history = createHistory(source);
+function createInMemoryRouter() {
+  let source;
+  if (
+    window.localStorage &&
+    !window.localStorage.getItem('isLandingPageShown')
+  ) {
+    window.localStorage.setItem('isLandingPageShown', 'true');
+    source = createMemorySource('/landing');
+  } else {
+    source = createMemorySource('/');
+  }
 
+  return createHistory(source);
+}
+
+const history = createInMemoryRouter();
+
+// Listen to location changes for logging tracking screens
 history.listen(({ location }) => {
   if (location.pathname === '' || location.pathname === '/') {
     trackScreen('main-screen');
@@ -50,16 +65,12 @@ const App = observer(() => {
     return () => dispose();
   }, []);
 
-  function navigateTo(path) {
-    history.navigate(path);
-  }
-
   return (
     <LocationProvider history={history}>
       <Router>
-        <Home path="/" navigateTo={navigateTo} />
+        <Landing path="/landing" />
+        <Home path="/" />
         <SSHSetup path="/oauth/*" />
-        <UpdateRemoteDirect path="/updateRemoteDirect" />
       </Router>
     </LocationProvider>
   );

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -97,7 +97,7 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked }) => {
             ) : (
               <div
                 className="w-48 h-48 flex my-4 flex-row justify-center items-center rounded-lg border-gray-500 border-2 border-dashed hover:border-blue-500 hover:bg-gray-200 cursor-pointer"
-                onClick={() => onNewSshKeyClicked(key)}>
+                onClick={() => onNewSshKeyClicked(provider)}>
                 <PlusIcon className="text-gray-700 w-8 h-8 font-semibold" />
                 <h1 className="ml-2 text-xl text-gray-700">New SSH key</h1>
               </div>

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -1,92 +1,26 @@
 import React from 'react';
 
-import AlphaBadge from '../../assets/img/alpha_badge.svg';
-import logo from '../../assets/logo/icon.png';
-
-import { Reveal, RevealGlobalStyles, Animation } from 'react-genie';
-import { trackScreen, trackEvent } from '../analytics';
-import Typical from 'react-typical';
+import { useNavigate } from '@reach/router';
 
 import { observer } from 'mobx-react-lite';
 import { useStore } from '../StoreProvider';
 
+import ProviderAccordion from '../components/ProviderAccordion';
+
+import logo from '../../assets/logo/icon.png';
 import PlusIcon from '../../assets/icons/plus_icon.svg';
 import ActionToolbar from '../components/ActionToolbar';
 
-import ProviderAccordion from '../components/ProviderAccordion';
+const Home = observer(() => {
+  const { keyStore } = useStore();
+  const navigate = useNavigate();
 
-function renderLandingPage(navigateTo) {
-  React.useEffect(() => {
-    trackScreen('landing-screen');
-  }, []);
-
-  return (
-    <div className="bg-gray-800 h-screen">
-      <RevealGlobalStyles />
-      <div className="flex justify-between">
-        <AlphaBadge className="z-10" />
-      </div>
-      <div className="flex flex-col items-center pb-8">
-        <Reveal delay={100}>
-          <img src={logo} className="w-20 h-20" />
-        </Reveal>
-        <Reveal delay={200}>
-          <h1 className="mt-2 font-semibold text-4xl mx-auto text-center text-gray-200">
-            Painlessly manage ssh keys for{' '}
-          </h1>
-        </Reveal>
-        <Reveal delay={500}>
-          <Typical
-            steps={TypicalSteps}
-            loop={1}
-            wrapper="span"
-            className="block font-semibold text-4xl mx-auto text-center text-gray-200"
-          />
-        </Reveal>
-        <Reveal delay={300}>
-          <h2 className="text-gray-200 text-lg mt-2 text-center">
-            Setup SSH keys in seconds 🚀
-          </h2>
-        </Reveal>
-        <div className="mt-12 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-5">
-          {steps.map((step, index) => (
-            <Reveal delay={400 + (index + 1) * 100}>
-              <div className="w-48 h-48 flex flex-col items-center border-blue-500 border-r-2 border-b-2 rounded-lg shadow-2xl bg-gray-900">
-                <div className="w-8 h-8 mt-4 text-gray-700 text-xl text-center font-semibold bg-gray-100 rounded-full shadow">
-                  {index + 1}
-                </div>
-                <h1 className="mt-4 px-4 text-2xl text-center font-bold text-gray-400">
-                  {step.title}
-                </h1>
-                <h2 className="mt-2 px-4 text-center text-xs font-semibold text-gray-400">
-                  {step.content}
-                </h2>
-              </div>
-            </Reveal>
-          ))}
-        </div>
-        <Reveal delay={1000} animation={Animation.SlideInRight}>
-          <button
-            className="w-48 px-4 py-2 mt-12 text-white text-xl font-semibold bg-blue-500 hover:bg-blue-700 rounded focus:outline-none"
-            onClick={_e => {
-              navigateTo('/oauth/connect');
-              trackEvent('splash', 'setup-ssh');
-            }}>
-            Get Started
-          </button>
-        </Reveal>
-      </div>
-    </div>
-  );
-}
-
-function renderHomePage(keyStore, navigateTo) {
   return (
     <div className="app bg-gray-300 min-h-screen ">
       <ActionToolbar
         title="ssh-git"
         logo={logo}
-        onPrimaryAction={() => navigateTo('/oauth/connect')}
+        onPrimaryAction={() => navigate('/oauth/connect')}
       />
       <div className="my-12 flex flex-col justify-start flex-wrap max-w-2xl xl:max-w-4xl mx-auto">
         {keyStore.totalNoOfKeys > 0 ? (
@@ -98,7 +32,7 @@ function renderHomePage(keyStore, navigateTo) {
             <ProviderAccordion
               keys={keyStore.keysGroupByProvider}
               onNewSshKeyClicked={_provider => {
-                navigateTo('/oauth/connect');
+                navigate('/oauth/connect');
               }}
             />
           </div>
@@ -109,7 +43,7 @@ function renderHomePage(keyStore, navigateTo) {
             </h1>
             <div
               className="mt-12 w-56 h-56 mx-4 flex flex-row justify-center items-center rounded-lg border-gray-500 border-2 border-dashed hover:border-blue-500 hover:bg-gray-200 cursor-pointer"
-              onClick={() => navigateTo('/oauth/connect')}>
+              onClick={() => navigate('/oauth/connect')}>
               <PlusIcon className="text-gray-700 w-8 h-8 font-semibold" />
               <h1 className="ml-2 text-xl text-gray-700">Setup SSH key</h1>
             </div>
@@ -118,50 +52,6 @@ function renderHomePage(keyStore, navigateTo) {
       </div>
     </div>
   );
-}
-
-const Home = observer(({ navigateTo }) => {
-  const { keyStore } = useStore();
-  if (
-    window.localStorage &&
-    !window.localStorage.getItem('isLandingPageShown')
-  ) {
-    window.localStorage.setItem('isLandingPageShown', 'true');
-    return renderLandingPage(navigateTo);
-  } else {
-    return renderHomePage(keyStore, navigateTo);
-  }
 });
 
 export default Home;
-
-const steps = [
-  {
-    title: 'Connect',
-    content: 'Connect to your account',
-  },
-  {
-    title: 'Generate',
-    content: 'Generate passphrase protected SSH key',
-  },
-  {
-    title: 'Add',
-    content: 'Add generated SSH key to your account',
-  },
-  {
-    title: 'Clone',
-    content: 'You can now clone, push, pull your repo',
-  },
-];
-
-const TypicalSteps = [
-  'Github',
-  2000,
-  'Bitbucket',
-  1000,
-  'Gitlab',
-  1000,
-  '',
-  1000,
-  'Github, Bitbucket and Gitlab accounts',
-];

--- a/src/renderer/pages/Landing.js
+++ b/src/renderer/pages/Landing.js
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import { useNavigate } from '@reach/router';
+
+import { Reveal, RevealGlobalStyles, Animation } from 'react-genie';
+import Typical from 'react-typical';
+
+import AlphaBadge from '../../assets/img/alpha_badge.svg';
+import logo from '../../assets/logo/icon.png';
+
+import { trackEvent } from '../analytics';
+
+export default function Landing() {
+  const navigate = useNavigate();
+  return (
+    <div className="bg-gray-800 h-screen">
+      <RevealGlobalStyles />
+      <div className="flex justify-between">
+        <AlphaBadge className="z-10" />
+      </div>
+      <div className="flex flex-col items-center pb-8">
+        <Reveal delay={100}>
+          <img src={logo} className="w-20 h-20" />
+        </Reveal>
+        <Reveal delay={200}>
+          <h1 className="mt-2 font-semibold text-4xl mx-auto text-center text-gray-200">
+            Painlessly manage ssh keys for{' '}
+          </h1>
+        </Reveal>
+        <Reveal delay={500}>
+          <Typical
+            steps={TypicalSteps}
+            loop={1}
+            wrapper="span"
+            className="block font-semibold text-4xl mx-auto text-center text-gray-200"
+          />
+        </Reveal>
+        <Reveal delay={300}>
+          <h2 className="text-gray-200 text-lg mt-2 text-center">
+            Setup SSH keys in seconds 🚀
+          </h2>
+        </Reveal>
+        <div className="mt-12 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-5">
+          {steps.map((step, index) => (
+            <Reveal delay={400 + (index + 1) * 100} key={step.title}>
+              <div className="w-48 h-48 flex flex-col items-center border-blue-500 border-r-2 border-b-2 rounded-lg shadow-2xl bg-gray-900">
+                <div className="w-8 h-8 mt-4 text-gray-700 text-xl text-center font-semibold bg-gray-100 rounded-full shadow">
+                  {index + 1}
+                </div>
+                <h1 className="mt-4 px-4 text-2xl text-center font-bold text-gray-400">
+                  {step.title}
+                </h1>
+                <h2 className="mt-2 px-4 text-center text-xs font-semibold text-gray-400">
+                  {step.content}
+                </h2>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+        <Reveal delay={1000} animation={Animation.SlideInRight}>
+          <button
+            className="w-48 px-4 py-2 mt-12 text-white text-xl font-semibold bg-blue-500 hover:bg-blue-700 rounded focus:outline-none"
+            onClick={_e => {
+              trackEvent('home', 'first-time');
+              navigate('/');
+            }}>
+            Get Started
+          </button>
+        </Reveal>
+      </div>
+    </div>
+  );
+}
+
+const steps = [
+  {
+    title: 'Connect',
+    content: 'Connect to your account',
+  },
+  {
+    title: 'Generate',
+    content: 'Generate passphrase protected SSH key',
+  },
+  {
+    title: 'Add',
+    content: 'Add generated SSH key to your account',
+  },
+  {
+    title: 'Clone',
+    content: 'You can now clone, push, pull your repo',
+  },
+];
+
+const TypicalSteps = [
+  'Github',
+  2000,
+  'Bitbucket',
+  1000,
+  'Gitlab',
+  1000,
+  '',
+  1000,
+  'Github, Bitbucket and Gitlab accounts',
+];

--- a/src/renderer/pages/sshsetup/SSHSetup.js
+++ b/src/renderer/pages/sshsetup/SSHSetup.js
@@ -1,6 +1,6 @@
 //Libs
-import React, { useState } from 'react';
-import { Router } from '@reach/router';
+import React from 'react';
+import { Router, useNavigate } from '@reach/router';
 
 //Components
 import Toolbar from '../../components/Toolbar';
@@ -12,15 +12,14 @@ import GenerateKey from './GenerateKey';
 import AddKey from './AddKey';
 import CloneRepo from './CloneRepo';
 
-//Internal
-import { history } from '../../App';
-
 const steps = ['Connect', 'Generate', 'Add', 'Clone'];
 
 export default function SSHSetup() {
-  const [activeStepIndex, setActiveStepIndex] = useState(0);
+  const [activeStepIndex, setActiveStepIndex] = React.useState(0);
+  const navigate = useNavigate();
+
   function goBackToHomeScreen() {
-    history.navigate('/');
+    navigate('/');
   }
 
   function onNext(path) {
@@ -41,7 +40,7 @@ export default function SSHSetup() {
       default:
         break;
     }
-    history.navigate(path);
+    navigate(path);
   }
 
   return (

--- a/src/renderer/pages/updateremote/UpdateRemoteDirect.js
+++ b/src/renderer/pages/updateremote/UpdateRemoteDirect.js
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useReducer } from 'react';
 
-import { history } from '../../App';
+import { useNavigate } from '@reach/router';
 
 // Components
 import Modal from '../../components/Modal';
@@ -19,6 +19,7 @@ import { web_base_url } from '../../../lib/config';
 import { trackEvent } from '../../analytics';
 
 export default function UpdateRemoteDirect() {
+  const navigate = useNavigate();
   const cloneRepoButtonRef = useRef(null); //Used in modal for focusing reason
   const updateRemoteUrlButtonRef = useRef(null); // Used in modal for focusing reason
 
@@ -190,11 +191,11 @@ export default function UpdateRemoteDirect() {
   // Navigation methods
 
   function navigateToHomeScreen() {
-    history.navigate('');
+    navigate('/');
   }
 
   function navigateToSshSetupScreen() {
-    history.navigate('oauth/connect');
+    navigate('oauth/connect');
   }
 
   // Render functions

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,16 +1858,15 @@
   resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.1.3.tgz#5d156319572dc38995b246f81878bc2577c517e5"
   integrity sha512-a1USH7L3bEfDdPN4iNZGvMEFuBfkdG+QNybeyDv8RloVFgZYRoM+KGXyy2KOfEnTUM8QWDRSROwaL3+ts5Angg==
 
-"@reach/router@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
-  integrity sha512-kTaX08X4g27tzIFQGRukaHmNbtMYDS3LEWIS8+l6OayGIw6Oyo1HIF/JzeuR2FoF9z6oV+x/wJSVSq4v8tcUGQ==
+"@reach/router@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.1.tgz#0a49f75fa9621323d6e21c803447bcfcde1713b2"
+  integrity sha512-Ov1j1J+pSgXliJHFL7XWhjyREwc6GxeWfgBTa5MMH5eRmYtHbPhaovba4xKo7aTVCg8fxkt2yDMNSpvwfUP+pA==
   dependencies:
-    create-react-context "^0.2.1"
+    create-react-context "0.3.0"
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
-    warning "^3.0.0"
 
 "@reach/visually-hidden@^0.1.4":
   version "0.1.4"
@@ -3453,13 +3452,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@^0.2.1:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
-  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
+create-react-context@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
+  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
   dependencies:
-    fbjs "^0.8.0"
     gud "^1.0.0"
+    warning "^4.0.3"
 
 cross-env@^6.0.3:
   version "6.0.3"
@@ -4517,7 +4516,7 @@ fastparse@^1.1.1:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
-fbjs@^0.8.0, fbjs@^0.8.1:
+fbjs@^0.8.1:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -9313,10 +9312,10 @@ wait-on@^3.3.0:
     request "^2.88.0"
     rx "^4.1.0"
 
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
- Updated **@reach/router** to **1.3.1** to use hooks.
- Created separate **Landing** page at path `/landing`.  Added it to top level routes.
- Home page code refactored.
- Moved checking in localStorage and based on flag showing either `Landing` or `Home` screen to **App.js** where it should be ideally. We're creating InMemoryRouter starting location based on that flag.
- Removed all navigateTo props and direct history import in some of pages and instead using `useNavigate` hook to get access to `navigate` function on **history** object. 