### PR TITLE
Feat : Clone and Update Actions in Dropdown Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "@rauschma/stringio": "^1.4.0",
+    "@reach/dialog": "^0.8.5",
     "@reach/router": "1.3.1",
     "@sentry/electron": "1.0.0",
     "axios": "^0.19.0",

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -116,9 +116,9 @@ function getCloneRepoCommand(
         `${selectedProvider}.com-${username}`
       );
     }
+  } else {
+    modifiedRepoUrl = repoUrl;
   }
-
-  modifiedRepoUrl = repoUrl;
 
   return `git clone ${modifiedRepoUrl} ${shallowClone ? '--depth=1' : ''} ${
     disableLogging ? `--quiet` : ''

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -210,6 +210,17 @@ async function cloneRepo(
   selectedFolder,
   shallowClone
 ) {
+  // Check if user has entered correct repo url based on currently selected provider
+  if (
+    repoUrl.startsWith('git@') &&
+    repoUrl.endsWith('.git') &&
+    !repoUrl.includes(selectedProvider)
+  ) {
+    throw new Error(
+      `Looks like you've entered the wrong repo url. It doesn't belongs to ${selectedProvider} account. Please check.`
+    );
+  }
+
   // Check if the repoUrl entered by user is a valid SSH url
   if (
     !(
@@ -220,17 +231,6 @@ async function cloneRepo(
   ) {
     throw new Error(
       'The SSH url you just entered is not correct one. Please enter correct SSH url'
-    );
-  }
-
-  // Check if user has entered correct repo url based on currently selected provider
-  if (
-    repoUrl.startsWith('git@') &&
-    repoUrl.endsWith('.git') &&
-    !repoUrl.includes(selectedProvider)
-  ) {
-    throw new Error(
-      `Looks like you've entered the wrong repo url. It doesn't belongs to ${selectedProvider} account. Please check.`
     );
   }
 

--- a/src/renderer/components/CloneRepoDialog.js
+++ b/src/renderer/components/CloneRepoDialog.js
@@ -1,0 +1,167 @@
+import React from 'react';
+
+import { DialogOverlay, DialogContent } from '@reach/dialog';
+import Switch from './Switch';
+
+import { openFolder, openExternal } from '../../lib/app-shell';
+import { web_base_url } from '../../lib/config';
+
+function cloneRepoReducer(state, action) {
+  switch (action.type) {
+    case 'CLONE_INIT':
+      return { ...state, isLoading: true, isError: false };
+    case 'CLONE_SUCCESS':
+      return {
+        ...state,
+        isLoading: false,
+        success: action.payload,
+        isError: false,
+      };
+    case 'CLONE_ERROR':
+      return { ...state, isLoading: false, isError: true };
+    case 'CLONE_RESET':
+      return { ...state, isLoading: false, isError: false, success: false };
+    default:
+      throw new Error(`Invalid action.type: ${action.type}`);
+  }
+}
+
+const CloneRepoDialog = ({ onDismiss, defaultSelectedFolder, SshKey }) => {
+  const [repoUrl, setRepoUrl] = React.useState('');
+  const [selectedFolder, setSelectedFolder] = React.useState(
+    defaultSelectedFolder
+  );
+  const [shallowClone, setShallowClone] = React.useState(false);
+
+  const [{ isLoading, isError, success }, dispatch] = React.useReducer(
+    cloneRepoReducer,
+    {
+      isLoading: false,
+      isError: false,
+      success: false,
+    }
+  );
+
+  async function onCloneRepoClicked() {
+    dispatch({ type: 'CLONE_INIT' });
+
+    const result = await window.ipc.callMain('clone-repo', {
+      selectedProvider: SshKey.provider,
+      username: SshKey.username,
+      mode: SshKey.mode,
+      repoUrl,
+      selectedFolder,
+      shallowClone,
+    });
+
+    const { success, repoFolder } = result;
+    if (success) {
+      dispatch({ type: 'CLONE_SUCCESS', payload: true });
+      setTimeout(() => openFolder(repoFolder), 1000);
+    } else {
+      dispatch({ type: 'CLONE_ERROR' });
+    }
+  }
+
+  async function onChangeSelectedFolderClicked() {
+    const selectedFolder = await window.ipc.callMain('select-git-folder');
+    if (selectedFolder) {
+      setSelectedFolder(selectedFolder);
+    }
+  }
+
+  return (
+    <DialogOverlay onDismiss={onDismiss} className="c-modal-cover">
+      <DialogContent aria-labelledby="clone-repo">
+        <div className="c-modal">
+          <button
+            className="c-modal__close"
+            aria-labelledby="close-modal"
+            onClick={onDismiss}>
+            <span className="u-hide-visually" id="close-modal">
+              Close
+            </span>
+            <svg className="c-modal__close-icon" viewBox="0 0 40 40">
+              <path d="M 10,10 L 30,30 M 30,10 L 10,30"></path>
+            </svg>
+          </button>
+          <h1 className="mt-4 text-2xl font-semibold" id="clone-repo">
+            Clone Repo
+          </h1>
+          <label className="text-gray-800 block text-left text-base mt-6 font-semibold">
+            Repo url
+          </label>
+          <input
+            type="text"
+            className="text-gray-800 text-base bg-gray-100 px-4 py-2 mt-2 rounded border-2 w-full"
+            placeholder="Enter your repository url."
+            value={repoUrl}
+            onChange={e => setRepoUrl(e.target.value)}
+          />
+          <p className="text-gray-600 text-sm mt-2">
+            [Example : git@github.com:nodejs/node.git]
+          </p>
+          <label className="text-gray-800 block text-left text-base mt-4 font-semibold">
+            Choose Folder
+          </label>
+          <div className="relative mt-2">
+            <input
+              type="text"
+              className="text-gray-800 text-base bg-gray-100 px-4 py-2 rounded border-2 w-full focus:outline-none"
+              value={selectedFolder}
+              readOnly
+            />
+            <button
+              className="bg-gray-300 hover:bg-gray-400 text-gray-700 hover:text-gray-800 px-4 text-center absolute right-0 top-0 bottom-0 rounded-r focus:outline-none"
+              onClick={onChangeSelectedFolderClicked}>
+              Choose
+            </button>
+          </div>
+          <div className="my-6 flex items-center">
+            <Switch
+              className="flex-1"
+              isOn={shallowClone}
+              handleToggle={() => setShallowClone(!shallowClone)}
+            />
+            <span className="flex-1 ml-2 text-gray-600">Shallow Clone</span>
+            <span
+              className="flex-0 text-gray-600 hover:text-gray-700 text-sm underline cursor-pointer"
+              onClick={() =>
+                openExternal(`${web_base_url}/questions/what-is-shallow-clone`)
+              }>
+              What is shallow clone?
+            </span>
+          </div>
+          <button
+            className={
+              isLoading
+                ? `primary-btn pr-12 generateKey`
+                : isError
+                ? `primary-btn-error`
+                : success
+                ? `primary-btn-success w-full`
+                : `primary-btn`
+            }
+            disabled={!(repoUrl && selectedFolder) || isLoading}
+            onClick={onCloneRepoClicked}>
+            {isLoading
+              ? 'Cloning Repo'
+              : isError
+              ? 'Retry'
+              : success
+              ? 'Cloned Successfully!'
+              : 'Clone'}
+          </button>
+          {isLoading && (
+            <p className="text-xs text-gray-600 mt-2">
+              This might take few seconds to minutes...You will be notified once
+              the repo is cloned.
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </DialogOverlay>
+  );
+};
+
+export default CloneRepoDialog;

--- a/src/renderer/components/CloneRepoDialog.js
+++ b/src/renderer/components/CloneRepoDialog.js
@@ -75,7 +75,7 @@ const CloneRepoDialog = ({ onDismiss, defaultSelectedFolder, SshKey }) => {
       <DialogContent aria-labelledby="clone-repo">
         <div className="c-modal">
           <button
-            className="c-modal__close"
+            className="c-modal__close focus:outline-none"
             aria-labelledby="close-modal"
             onClick={onDismiss}>
             <span className="u-hide-visually" id="close-modal">

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -22,6 +22,41 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked }) => {
     setShowProviderKeys(updatedProviders);
   }
 
+  function onActionClicked(actionType, key) {
+    switch (actionType) {
+      case 'CLONE_REPO':
+        console.group('--- Cloning Repo ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Cloning Repo ---');
+        break;
+      case 'UPDATE_REMOTE':
+        console.group('--- Updating Remote Url ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Updating Remote Url ---');
+        break;
+      case 'DELETE_KEY':
+        console.group('--- Deleting Key ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Deleting Key ---');
+        break;
+      case 'OPEN_PROFILE':
+        console.group('--- Opening Profile ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Opening   ---');
+        break;
+      default:
+        break;
+    }
+  }
+
   return Object.entries(keys).map(([provider, keys]) => {
     const image = images[provider];
     return (
@@ -62,7 +97,42 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked }) => {
                     alt={`${image.name} avatar`}
                     className="h-12 w-12 mx-auto object-cover rounded-full border-2 border-gray-200 shadow-lg -mt-6 bg-gray-200"
                   />
-                  <OverflowMenuIcon className="w-6 h-6 text-gray-600 hover:text-gray-800 absolute right-0 top-0 mt-2" />
+                  <div className="absolute right-0 top-0 mt-2">
+                    <div className="group inline-block hover:block relative">
+                      <OverflowMenuIcon className="w-6 h-6 text-gray-600 hover:text-gray-800" />
+                      <ul className="hidden group-hover:block absolute right-0 top-0 text-gray-700 mr-1 mt-6 z-10 text-sm rounded-md bg-white shadow-xs">
+                        {key.mode === 'SINGLE'
+                          ? singleModeActions.map((action, index) => (
+                              <li
+                                className={`${index === 0 ? `rounded-t` : ``} ${
+                                  index === 2
+                                    ? `rounded-b`
+                                    : `border-b-2 border-gray-200`
+                                } bg-gray-100 hover:bg-gray-300 py-2 px-4 block whitespace-no-wrap`}
+                                key={action.name}
+                                onClick={_e =>
+                                  onActionClicked(action.type, key)
+                                }>
+                                {action.name}
+                              </li>
+                            ))
+                          : multiModeActions.map((action, index) => (
+                              <li
+                                className={`${index === 0 ? `rounded-t` : ``} ${
+                                  index === 3
+                                    ? `rounded-b`
+                                    : `border-b-2 border-gray-200`
+                                } bg-gray-100 hover:bg-gray-300 py-2 px-4 block whitespace-no-wrap`}
+                                key={action.name}
+                                onClick={_e =>
+                                  onActionClicked(action.type, key)
+                                }>
+                                {action.name}
+                              </li>
+                            ))}
+                      </ul>
+                    </div>
+                  </div>
                   {key.username ? (
                     <h1 className="text-xl text-gray-700 font-semibold mt-4">
                       {key.username}
@@ -126,3 +196,37 @@ const images = {
     icon: gitlablogo,
   },
 };
+
+const singleModeActions = [
+  {
+    name: 'Clone Repo',
+    type: 'CLONE_REPO',
+  },
+  {
+    name: 'Delete Key',
+    type: 'DELETE_KEY',
+  },
+  {
+    name: 'Open Profile',
+    type: 'OPEN_PROFILE',
+  },
+];
+
+const multiModeActions = [
+  {
+    name: 'Clone Repo',
+    type: 'CLONE_REPO',
+  },
+  {
+    name: 'Update Remote',
+    type: 'UPDATE_REMOTE',
+  },
+  {
+    name: 'Delete Key',
+    type: 'DELETE_KEY',
+  },
+  {
+    name: 'Open Profile',
+    type: 'OPEN_PROFILE',
+  },
+];

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -122,7 +122,9 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
                         Update Remote
                       </button>
                     ) : (
-                      <button className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none">
+                      <button
+                        className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none"
+                        onClick={() => onActionClicked('CLONE_REPO', key)}>
                         Clone Repo
                       </button>
                     )}

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -9,7 +9,7 @@ import OverflowMenuIcon from '../../assets/icons/overflow_menu.svg';
 import ChevronRight from '../../assets/icons/chevron_right.svg';
 import ChevronDown from '../../assets/icons/chevron_down.svg';
 
-const ProviderAccordion = ({ keys, onNewSshKeyClicked }) => {
+const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
   const [showProviderKeys, setShowProviderKeys] = React.useState({
     github: false,
     bitbucket: false,
@@ -20,41 +20,6 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked }) => {
     showProviderKeys[key] = !showProviderKeys[key];
     const updatedProviders = { ...showProviderKeys };
     setShowProviderKeys(updatedProviders);
-  }
-
-  function onActionClicked(actionType, key) {
-    switch (actionType) {
-      case 'CLONE_REPO':
-        console.group('--- Cloning Repo ---');
-        console.log('mode: ', key.mode);
-        console.log('username: ', key.username);
-        console.log('provider: ', key.provider);
-        console.groupEnd('--- Cloning Repo ---');
-        break;
-      case 'UPDATE_REMOTE':
-        console.group('--- Updating Remote Url ---');
-        console.log('mode: ', key.mode);
-        console.log('username: ', key.username);
-        console.log('provider: ', key.provider);
-        console.groupEnd('--- Updating Remote Url ---');
-        break;
-      case 'DELETE_KEY':
-        console.group('--- Deleting Key ---');
-        console.log('mode: ', key.mode);
-        console.log('username: ', key.username);
-        console.log('provider: ', key.provider);
-        console.groupEnd('--- Deleting Key ---');
-        break;
-      case 'OPEN_PROFILE':
-        console.group('--- Opening Profile ---');
-        console.log('mode: ', key.mode);
-        console.log('username: ', key.username);
-        console.log('provider: ', key.provider);
-        console.groupEnd('--- Opening   ---');
-        break;
-      default:
-        break;
-    }
   }
 
   return Object.entries(keys).map(([provider, keys]) => {
@@ -98,7 +63,7 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked }) => {
                     className="h-12 w-12 mx-auto object-cover rounded-full border-2 border-gray-200 shadow-lg -mt-6 bg-gray-200"
                   />
                   <div className="absolute right-0 top-0 mt-2">
-                    <div className="group inline-block hover:block relative">
+                    <div className="group inline-block relative">
                       <OverflowMenuIcon className="w-6 h-6 text-gray-600 hover:text-gray-800" />
                       <ul className="hidden group-hover:block absolute right-0 top-0 text-gray-700 mr-1 mt-6 z-10 text-sm rounded-md bg-white shadow-xs">
                         {key.mode === 'SINGLE'

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -119,13 +119,13 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
                   <div className="absolute bottom-0 w-full">
                     {key.mode === 'MULTI' ? (
                       <button
-                        className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none"
+                        className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none focus:outline-none"
                         onClick={() => onActionClicked('UPDATE_REMOTE', key)}>
                         Update Remote
                       </button>
                     ) : (
                       <button
-                        className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none"
+                        className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none focus:outline-none"
                         onClick={() => onActionClicked('CLONE_REPO', key)}>
                         Clone Repo
                       </button>

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -118,7 +118,9 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
 
                   <div className="absolute bottom-0 w-full">
                     {key.mode === 'MULTI' ? (
-                      <button className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none">
+                      <button
+                        className="bg-gray-300 hover:bg-gray-400 w-full h-12 text-gray-700 hover:text-gray-800 text-sm rounded-b-lg rounded-t-none"
+                        onClick={() => onActionClicked('UPDATE_REMOTE', key)}>
                         Update Remote
                       </button>
                     ) : (

--- a/src/renderer/components/UpdateRemoteDialog.js
+++ b/src/renderer/components/UpdateRemoteDialog.js
@@ -1,0 +1,126 @@
+import React from 'react';
+
+import { DialogContent, DialogOverlay } from '@reach/dialog';
+
+function updateRemoteReducer(state, action) {
+  switch (action.type) {
+    case 'UPDATE_REMOTE_INIT':
+      return { ...state, isLoading: true, isError: false };
+    case 'UPDATE_REMOTE_SUCCESS':
+      return {
+        ...state,
+        isLoading: false,
+        success: action.payload,
+        isError: false,
+      };
+    case 'UPDATE_REMOTE_ERROR':
+      return { ...state, isLoading: false, isError: true };
+    case 'UPDATE_REMOTE_RESET':
+      return { ...state, isLoading: false, isError: false, success: false };
+    default:
+      throw new Error(`Invalid action.type: ${action.type}`);
+  }
+}
+
+const UpdateRemoteDialog = ({ onDismiss, defaultSelectedFolder, SshKey }) => {
+  const [selectedFolder, setSelectedFolder] = React.useState(
+    defaultSelectedFolder
+  );
+
+  const [{ isLoading, isError, success }, dispatch] = React.useReducer(
+    updateRemoteReducer,
+    {
+      isLoading: false,
+      isError: false,
+      success: false,
+    }
+  );
+
+  async function onChangeSelectedFolderClicked() {
+    const selectedFolder = await window.ipc.callMain('select-git-folder');
+    if (selectedFolder) {
+      setSelectedFolder(selectedFolder);
+    }
+  }
+
+  async function onUpdateRemoteUrlClicked() {
+    dispatch({ type: 'UPDATE_REMOTE_INIT' });
+
+    const result = await window.ipc.callMain('update-remote-url', {
+      selectedProvider: SshKey.provider,
+      username: SshKey.username,
+      repoFolder: selectedFolder,
+    });
+
+    const { success } = result;
+
+    if (success) {
+      dispatch({ type: 'UPDATE_REMOTE_SUCCESS', payload: true });
+    } else {
+      dispatch({ type: 'UPDATE_REMOTE_ERROR' });
+    }
+  }
+
+  return (
+    <DialogOverlay onDismiss={onDismiss} className="c-modal-cover">
+      <DialogContent aria-labelledby="update-remote">
+        <div className="c-modal">
+          <button
+            className="c-modal__close"
+            aria-labelledby="close-modal"
+            onClick={onDismiss}>
+            <span className="u-hide-visually" id="close-modal">
+              Close
+            </span>
+            <svg className="c-modal__close-icon" viewBox="0 0 40 40">
+              <path d="M 10,10 L 30,30 M 30,10 L 10,30"></path>
+            </svg>
+          </button>
+          <h1 className="mt-4 text-2xl font-semibold" id="update-remote">
+            Update Remote Url
+          </h1>
+          <label className="text-gray-800 block text-left text-base mt-4 font-semibold">
+            Select Repo Folder
+          </label>
+          <div className="relative mb-6 mt-2">
+            <input
+              type="text"
+              className="text-gray-800 text-base bg-gray-100 px-4 py-2 rounded border-2 w-full focus:outline-none"
+              value={selectedFolder}
+              placeholder="Select Repo Folder"
+              readOnly
+              onClick={onChangeSelectedFolderClicked}
+            />
+            <button
+              className="bg-gray-300 hover:bg-gray-400 text-gray-700 hover:text-gray-800 px-4 text-center absolute right-0 top-0 bottom-0 rounded-r focus:outline-none "
+              onClick={onChangeSelectedFolderClicked}>
+              Select
+            </button>
+          </div>
+          <button
+            className={
+              isLoading
+                ? `primary-btn pr-12 generateKey`
+                : isError
+                ? `primary-btn-error`
+                : success
+                ? `primary-btn-success w-full`
+                : `primary-btn`
+            }
+            disabled={!selectedFolder || isLoading}
+            onClick={onUpdateRemoteUrlClicked}>
+            {isLoading
+              ? 'Upating Remote Url'
+              : isError
+              ? 'Retry'
+              : success
+              ? 'Remote Url Updated!'
+              : 'Update Remote Url'}
+          </button>
+        </div>
+      </DialogContent>
+    </DialogOverlay>
+  );
+};
+
+export default UpdateRemoteDialog;

--- a/src/renderer/components/UpdateRemoteDialog.js
+++ b/src/renderer/components/UpdateRemoteDialog.js
@@ -66,7 +66,7 @@ const UpdateRemoteDialog = ({ onDismiss, defaultSelectedFolder, SshKey }) => {
       <DialogContent aria-labelledby="update-remote">
         <div className="c-modal">
           <button
-            className="c-modal__close"
+            className="c-modal__close focus:outline-none"
             aria-labelledby="close-modal"
             onClick={onDismiss}>
             <span className="u-hide-visually" id="close-modal">

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -12,16 +12,17 @@ import PlusIcon from '../../assets/icons/plus_icon.svg';
 import ActionToolbar from '../components/ActionToolbar';
 
 import CloneRepoDialog from '../components/CloneRepoDialog';
+import UpdateRemoteDialog from '../components/UpdateRemoteDialog';
 
 const Home = observer(() => {
   const { keyStore } = useStore();
   const navigate = useNavigate();
+
   const [currentKey, setCurrentKey] = React.useState(null);
-
   const [showCloneDialog, setShowCloneRepoDialog] = React.useState(false);
-  const openCloneRepoDialog = () => setShowCloneRepoDialog(true);
-  const closeCloneRepoialog = () => setShowCloneRepoDialog(false);
-
+  const [showUpdateRemoteDialog, setShowUpdateRemoteDialog] = React.useState(
+    false
+  );
   const [desktopFolder, setDesktopFolder] = React.useState('');
 
   React.useEffect(() => {
@@ -39,14 +40,15 @@ const Home = observer(() => {
     }
   }, [desktopFolder]);
 
+  const openCloneRepoDialog = () => setShowCloneRepoDialog(true);
+  const closeCloneRepoDialog = () => setShowCloneRepoDialog(false);
+
+  const openUpdateRemoteDialog = () => setShowUpdateRemoteDialog(true);
+  const closeUpdateRemoteDialog = () => setShowUpdateRemoteDialog(false);
+
   function onActionClicked(actionType, key) {
     switch (actionType) {
       case 'CLONE_REPO':
-        console.group('--- Cloning Repo ---');
-        console.log('mode: ', key.mode);
-        console.log('username: ', key.username);
-        console.log('provider: ', key.provider);
-        console.groupEnd('--- Cloning Repo ---');
         setCurrentKey(key);
         openCloneRepoDialog();
         break;
@@ -56,6 +58,8 @@ const Home = observer(() => {
         console.log('username: ', key.username);
         console.log('provider: ', key.provider);
         console.groupEnd('--- Updating Remote Url ---');
+        setCurrentKey(key);
+        openUpdateRemoteDialog();
         break;
       case 'DELETE_KEY':
         console.group('--- Deleting Key ---');
@@ -114,7 +118,15 @@ const Home = observer(() => {
       </div>
       {showCloneDialog ? (
         <CloneRepoDialog
-          onDismiss={closeCloneRepoialog}
+          onDismiss={closeCloneRepoDialog}
+          defaultSelectedFolder={desktopFolder}
+          SshKey={currentKey}
+        />
+      ) : null}
+
+      {showUpdateRemoteDialog ? (
+        <UpdateRemoteDialog
+          onDismiss={closeUpdateRemoteDialog}
           defaultSelectedFolder={desktopFolder}
           SshKey={currentKey}
         />

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -11,9 +11,70 @@ import logo from '../../assets/logo/icon.png';
 import PlusIcon from '../../assets/icons/plus_icon.svg';
 import ActionToolbar from '../components/ActionToolbar';
 
+import CloneRepoDialog from '../components/CloneRepoDialog';
+
 const Home = observer(() => {
   const { keyStore } = useStore();
   const navigate = useNavigate();
+  const [currentKey, setCurrentKey] = React.useState(null);
+
+  const [showCloneDialog, setShowCloneRepoDialog] = React.useState(false);
+  const openCloneRepoDialog = () => setShowCloneRepoDialog(true);
+  const closeCloneRepoialog = () => setShowCloneRepoDialog(false);
+
+  const [desktopFolder, setDesktopFolder] = React.useState('');
+
+  React.useEffect(() => {
+    // Making sure that we ask for desktop folder path only
+    // when `selectedFolder` is empty('') which would happen
+    // in case "clone repo" dialog is closed and re-opened again and during 1st time when selectedFolder isn't set yet.
+    async function getSystemDesktopFolderPath() {
+      const desktopFolderPath = await window.ipc.callMain(
+        'get-system-desktop-path'
+      );
+      setDesktopFolder(desktopFolderPath);
+    }
+    if (!desktopFolder) {
+      getSystemDesktopFolderPath();
+    }
+  }, [desktopFolder]);
+
+  function onActionClicked(actionType, key) {
+    switch (actionType) {
+      case 'CLONE_REPO':
+        console.group('--- Cloning Repo ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Cloning Repo ---');
+        setCurrentKey(key);
+        openCloneRepoDialog();
+        break;
+      case 'UPDATE_REMOTE':
+        console.group('--- Updating Remote Url ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Updating Remote Url ---');
+        break;
+      case 'DELETE_KEY':
+        console.group('--- Deleting Key ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Deleting Key ---');
+        break;
+      case 'OPEN_PROFILE':
+        console.group('--- Opening Profile ---');
+        console.log('mode: ', key.mode);
+        console.log('username: ', key.username);
+        console.log('provider: ', key.provider);
+        console.groupEnd('--- Opening   ---');
+        break;
+      default:
+        break;
+    }
+  }
 
   return (
     <div className="app bg-gray-300 min-h-screen ">
@@ -34,6 +95,7 @@ const Home = observer(() => {
               onNewSshKeyClicked={_provider => {
                 navigate('/oauth/connect');
               }}
+              onActionClicked={onActionClicked}
             />
           </div>
         ) : (
@@ -50,6 +112,13 @@ const Home = observer(() => {
           </div>
         )}
       </div>
+      {showCloneDialog ? (
+        <CloneRepoDialog
+          onDismiss={closeCloneRepoialog}
+          defaultSelectedFolder={desktopFolder}
+          SshKey={currentKey}
+        />
+      ) : null}
     </div>
   );
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
   },
   variants: {
     borderWidth: ['responsive', 'hover', 'focus'],
+    display: ['responsive', 'hover', 'focus', 'group-hover'],
   },
   plugins: [require('./plugins/gradients')],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,6 +1858,25 @@
   resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.1.3.tgz#5d156319572dc38995b246f81878bc2577c517e5"
   integrity sha512-a1USH7L3bEfDdPN4iNZGvMEFuBfkdG+QNybeyDv8RloVFgZYRoM+KGXyy2KOfEnTUM8QWDRSROwaL3+ts5Angg==
 
+"@reach/dialog@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.8.5.tgz#e6768897656b3322159ff0e3cb839124f4a9c6c2"
+  integrity sha512-2PqYVTKwGWGGA0O5wc/2+KBsBTqNxbO2P/fW0KWVH6expfDMr5TtBTiHxeF9VS8KmAlSFn2OrUXDIAXozL0zuQ==
+  dependencies:
+    "@reach/portal" "^0.8.5"
+    "@reach/utils" "^0.8.5"
+    prop-types "^15.7.2"
+    react-focus-lock "^2.2.1"
+    react-remove-scroll "^2.2.0"
+    tslib "^1.10.0"
+
+"@reach/portal@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.8.5.tgz#586e8686e9ba34368b1df3fc9a84c3ef923dd2d3"
+  integrity sha512-YRQgItjxw6DznndN4T3YS6Ikuq+FPZg8fekXeM1feuQSnMlAtEAyYVaMhpAKSD65+Yc9Zu0Utfxp5ji+wO+FLg==
+  dependencies:
+    tslib "^1.10.0"
+
 "@reach/router@1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.1.tgz#0a49f75fa9621323d6e21c803447bcfcde1713b2"
@@ -1867,6 +1886,14 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
+
+"@reach/utils@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.8.5.tgz#6675d6f81054c8dce1b9d535280b0e3c5174fe7d"
+  integrity sha512-nc84exIqBa+EohJPBFjePQP88dBAP4l+tChxwWszzZ+R6tTtSgOg40WyQ5EjPYJFbltnbZIbASHefcEBrFxqng==
+  dependencies:
+    tslib "^1.10.0"
+    warning "^4.0.3"
 
 "@reach/visually-hidden@^0.1.4":
   version "0.1.4"
@@ -3919,6 +3946,11 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+detect-node@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
+  integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
 detective@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz#feb2a77e85b904ecdea459ad897cc90a99bd2a7b"
@@ -4571,6 +4603,11 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+focus-lock@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.6.tgz#98119a755a38cfdbeda0280eaa77e307eee850c7"
+  integrity sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -5221,7 +5258,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.2, invariant@^2.2.3:
+invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -7423,7 +7460,7 @@ promise@^7.0.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7570,6 +7607,13 @@ react-animations@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-animations/-/react-animations-1.0.0.tgz#d96222920dfeabec8984d9b2ef2c5a5aadb40f06"
   integrity sha512-ePPpVgdKnNEXm+LP1ww5s3n0JzebBw9QdRfxRqogzeg1PDIn6kf0pmvgeTeVZQXXpGmHImkIeTiaQR1O6xjntA==
 
+react-clientside-effect@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
+  integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 react-confetti@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-5.0.1.tgz#3003570778cafad4db0ab5513018d4c10e9d1271"
@@ -7586,6 +7630,18 @@ react-dom@^16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+react-focus-lock@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.2.1.tgz#1d12887416925dc53481914b7cedd39494a3b24a"
+  integrity sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.6.6"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.2"
+    use-callback-ref "^1.2.1"
+    use-sidecar "^1.0.1"
 
 react-genie@^0.1.5:
   version "0.1.5"
@@ -7620,6 +7676,25 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-remove-scroll-bar@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.0.0.tgz#94437a7f3dbda99817ff64b928ee206e298ba157"
+  integrity sha512-HSdWZ+6vV6X1btLRhQlIcFulaMePCyg0Un2oXMmDdq8lK9KPUMSnWYINYWVCdgT35em9hiUaR8frBN1PYYLLpQ==
+  dependencies:
+    react-style-singleton "^2.0.0"
+    tslib "^1.0.0"
+
+react-remove-scroll@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.2.0.tgz#f42e6a4791ebfcce2c96f970d24deb1399fa9550"
+  integrity sha512-bT29xAkNuhS2tnsxhLNJrmmb6Rn8VsnlOfSoRaKdKi90DbhRcQfJ9vHG1TtgfkCP+rx059vCGIScPZaCWsyIKA==
+  dependencies:
+    react-remove-scroll-bar "^2.0.0"
+    react-style-singleton "^2.0.0"
+    tslib "^1.0.0"
+    use-callback-ref "^1.2.1"
+    use-sidecar "^1.0.1"
+
 react-spinners@^0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.5.13.tgz#09da41ee6b321083ff9670cbf78e11effb3feb87"
@@ -7636,6 +7711,14 @@ react-spring@^8.0.27:
   dependencies:
     "@babel/runtime" "^7.3.1"
     prop-types "^15.5.8"
+
+react-style-singleton@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.0.0.tgz#fdc9ff3a82674c256f0033d140b7b1d9d37e7f17"
+  integrity sha512-1Kw9G/b7EqLspjtiKsC9jtoqkx+RAti+8PmBe47ioKTcdhB3gtaKw2Lc3Hsud/VrXh+QECZKmr2yDCwR7ObNtA==
+  dependencies:
+    invariant "^2.2.4"
+    tslib "^1.0.0"
 
 react-typical@^0.1.3:
   version "0.1.3"
@@ -8985,6 +9068,11 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
+tslib@^1.0.0, tslib@^1.10.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -9200,6 +9288,19 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-callback-ref@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
+  integrity sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==
+
+use-sidecar@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.2.tgz#e72f582a75842f7de4ef8becd6235a4720ad8af6"
+  integrity sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==
+  dependencies:
+    detect-node "^2.0.4"
+    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
- Added Dropdown Menu on Cards
- Added following menu items based on key mode:
      **SINGLE**:
         - Clone Repo,
         - Delete Key
         - Open Profile

     **MULTI**:
         - Clone Repo
         - Update Remote
         - Delete Key
         - Open Profile

I might remove "Open Profile" in both modes and will probably do it in next release with separate Profile page/modal. Keeping it for time being.

- Added [@reach/dialog](https://reacttraining.com/reach-ui/dialog/) to create individual "CloneRepoDialog" and "UpdateRemoteDialog" modal components. This modals can now be reused across screens. 

- Actions generated from Menu Items - **'Clone Repo'** and **'Update Remote'** open 'CloneRepoDialog' and 'UpdateRemoteDialog' respectively for corresponding Ssh key.

- Primary actions in Cards like "Clone Repo"(single mode) and "Update Remote"(multi mode) are now linked to modals(CloneRepoDialog and UpdateRemoteDialog) as well. 



**Few bug fixes:**
- Fixed some issues related to core Clone Repo functionality where we were setting wrong modifiedUrl for multi mode Ssh key when cloning the repo. 

- Fixed validation order issue in core for showing correct error message when doing Update Remote. in core.