### PR TITLE
Feat : Delete SSH Key

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -14,6 +14,7 @@ const {
   parseSSHConfigFile,
   doKeyAlreadyExists,
   getRsaFilePath,
+  deleteKey,
 } = require('./core');
 
 // dialog wrapper
@@ -28,6 +29,7 @@ const { KeyStore } = require('./ElectronStore');
 function register() {
   registerIpcForStore();
   registerGeneralIpcs();
+  registerIpcForHomeScreen();
   registerIpcForConnectAccountScreen();
   registerIpcForGenerateKeyScreen();
   registerIpcForAddKeyScreen();
@@ -63,6 +65,22 @@ function registerGeneralIpcs() {
   ipc.answerRenderer('open-folder', async folderPath => {
     shell.openItem(folderPath);
     return;
+  });
+}
+
+function registerIpcForHomeScreen() {
+  ipc.answerRenderer('delete-key', async SshKey => {
+    try {
+      await deleteKey(SshKey);
+      return true;
+    } catch (error) {
+      setTimeout(() =>
+        dialog.showErrorDialog(
+          error.message ? error.message : 'Something went wrong.'
+        )
+      );
+      return false;
+    }
   });
 }
 

--- a/src/renderer/components/DeleteKeyDialog.js
+++ b/src/renderer/components/DeleteKeyDialog.js
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { DialogOverlay, DialogContent } from '@reach/dialog';
+
+const DeleteKeyDialog = ({ onDismiss, onKeyDeleted, SshKey }) => {
+  return (
+    <DialogOverlay onDismiss={onDismiss} className="c-modal-cover">
+      <DialogContent aria-labelledby="confirmation">
+        <div className="c-modal">
+          <button
+            className="c-modal__close focus:outline-none"
+            aria-labelledby="close-modal"
+            onClick={onDismiss}>
+            <span className="u-hide-visually" id="close-modal">
+              Close
+            </span>
+            <svg className="c-modal__close-icon" viewBox="0 0 40 40">
+              <path d="M 10,10 L 30,30 M 30,10 L 10,30"></path>
+            </svg>
+          </button>
+          <div className="flex flex-col justify-center">
+            <div className="flex justify-start items-center mt-4">
+              <svg
+                className="h-6 w-6 text-red-600"
+                stroke="currentColor"
+                fill="none"
+                viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+              <h1 className="text-2xl font-semibold ml-2" id="confirmation">
+                Confirm
+              </h1>
+            </div>
+            <h2 className="mt-4 text-gray-700 text-lg">
+              {`Are you sure you want to delete SSH key for ${SshKey.provider} account?`}
+            </h2>
+            <div className="flex flex-row justify-end mt-4">
+              <button
+                className="px-6 py-2 text-base text-gray-600 hover:text-gray-700 bg-gray-200 hover:bg-gray-300 rounded font-bold focus:outline-none"
+                onClick={onDismiss}>
+                Cancel
+              </button>
+
+              <button
+                onClick={onKeyDeleted}
+                className="ml-4 px-6 py-2 text-base text-white bg-red-600 hover:bg-red-500 border-0 rounded border-transparent focus:outline-none">
+                Delete Key
+              </button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </DialogOverlay>
+  );
+};
+
+export default DeleteKeyDialog;

--- a/src/renderer/components/DeleteKeyDialog.js
+++ b/src/renderer/components/DeleteKeyDialog.js
@@ -41,14 +41,14 @@ const DeleteKeyDialog = ({ onDismiss, onKeyDeleted, SshKey }) => {
             </h2>
             <div className="flex flex-row justify-end mt-4">
               <button
-                className="px-6 py-2 text-base text-gray-600 hover:text-gray-700 bg-gray-200 hover:bg-gray-300 rounded font-bold focus:outline-none"
+                className="px-6 py-2 text-base text-gray-600 hover:text-gray-700 font-medium bg-gray-200 hover:bg-gray-300 rounded focus:outline-none"
                 onClick={onDismiss}>
                 Cancel
               </button>
 
               <button
                 onClick={onKeyDeleted}
-                className="ml-4 px-6 py-2 text-base text-white bg-red-600 hover:bg-red-500 border-0 rounded border-transparent focus:outline-none">
+                className="ml-4 px-6 py-2 text-base text-white font-medium bg-red-600 hover:bg-red-500 border-0 rounded border-transparent focus:outline-none">
                 Delete Key
               </button>
             </div>

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -132,20 +132,10 @@ const Home = observer(() => {
         openUpdateRemoteDialog();
         break;
       case 'DELETE_KEY':
-        console.group('--- Deleting Key ---');
-        console.log('mode: ', key.mode);
-        console.log('username: ', key.username);
-        console.log('provider: ', key.provider);
-        console.groupEnd('--- Deleting Key ---');
         setCurrentKey(key);
         openDeleteKeyDialog();
         break;
       case 'OPEN_PROFILE':
-        console.group('--- Opening Profile ---');
-        console.log('mode: ', key.mode);
-        console.log('username: ', key.username);
-        console.log('provider: ', key.provider);
-        console.groupEnd('--- Opening   ---');
         break;
       case 'ADD_LABEL':
         setCurrentKey(key);

--- a/src/renderer/pages/sshsetup/GenerateKey.js
+++ b/src/renderer/pages/sshsetup/GenerateKey.js
@@ -284,7 +284,7 @@ const GenerateKey = observer(({ onNext }) => {
     if (success) {
       sessionStore.addKeyPath(rsaFilePath);
       if (keyAlreadyExistsInKeyStore) {
-        keyStore.removeKey(sessionStore.provider, sessionStore.username);
+        keyStore.removeKey(sessionStore);
       }
       dispatch({ type: 'FETCH_SUCCESS', payload: { keyGenerated: true } });
       setTimeout(() => onNext('oauth/add'), 1500);

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -84,9 +84,12 @@ const KeyStore = types
         label,
       });
     },
-    removeKey(provider, username) {
+    removeKey(key) {
       const keyIndex = self.sshKeys.findIndex(
-        sshKey => sshKey.provider === provider && sshKey.username === username
+        sshKey =>
+          (sshKey.provider === key.provider &&
+            sshKey.username === key.username) ||
+          (sshKey.provider === key.provider && sshKey.path === key.path)
       );
       if (keyIndex !== -1) self.sshKeys.splice(keyIndex, 1);
     },


### PR DESCRIPTION
- Users can now **delete SSH key** from `Home` screen 🎉.
- We're removing SSH key by doing following 3 things:
   - Deleting it from File System from `.ssh` directory
   - Removing particular ssh config using [ssh-config](https://github.com/cyjake/ssh-config) library based on currently selected key's provider, mode and username. Once the config is removed, we're overriding ssh config file with new config contents.
   - Removing Key from `keyStore`(MobX) so it is immediately reflected on Home screen UI. 
- Created DeleteKeyDialog component
- Replaced all `utils.promisify` -> with `promisified fs` methods. 
- Fixed `removeKey(keyToDelete)` action on **Keystore** in MobX to consider for scenario where username could be empty and also check for combination for provider and keyPath(which is always available) to remove key in that case .