### PR TITLE
Bug : UI Fixes

### DIFF
--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -32,9 +32,12 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
           <div className="flex items-center justify-start">
             <img
               src={image.icon}
-              className="inline w-8 h-8 object-cover rounded-full"
+              width={image.width}
+              height={image.height}
+              className={`${image.padding} inline object-cover rounded-full`}
             />
-            <h1 className="inline text-gray-900 text-xl font-semibold capitalize ml-2">
+            <h1
+              className={`${image.textPadding} inline text-gray-800 text-xl font-semibold capitalize`}>
               {provider}
             </h1>
           </div>
@@ -146,7 +149,6 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
       </div>
     );
   });
-  g;
 };
 
 export default ProviderAccordion;
@@ -155,14 +157,26 @@ const images = {
   github: {
     displayName: 'GitHub',
     icon: githublogo,
+    width: '23',
+    height: '23',
+    padding: 'ml-1',
+    textPadding: 'ml-2',
   },
   bitbucket: {
     displayName: 'Bitbucket',
     icon: bitbucketlogo,
+    width: '30',
+    height: '30',
+    padding: 'ml-px',
+    textPadding: 'ml-1',
   },
   gitlab: {
     displayName: 'GitLab',
     icon: gitlablogo,
+    width: '34',
+    height: '34',
+    padding: '-ml-px',
+    textPadding: 'ml-px',
   },
 };
 

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -175,10 +175,6 @@ const singleModeActions = [
     name: 'Delete Key',
     type: 'DELETE_KEY',
   },
-  {
-    name: 'Open Profile',
-    type: 'OPEN_PROFILE',
-  },
 ];
 
 const multiModeActions = [
@@ -193,9 +189,5 @@ const multiModeActions = [
   {
     name: 'Delete Key',
     type: 'DELETE_KEY',
-  },
-  {
-    name: 'Open Profile',
-    type: 'OPEN_PROFILE',
   },
 ];

--- a/src/renderer/hooks/useLottieAnimation.js
+++ b/src/renderer/hooks/useLottieAnimation.js
@@ -4,6 +4,10 @@ import lottie from 'lottie-web';
 export default function useLottieAnimation(animationData, elementRef) {
   const ref = React.useRef(null);
 
+  React.useEffect(() => {
+    return () => lottie.destroy();
+  }, []);
+
   if (ref.current === null && elementRef.current !== null) {
     ref.current = lottie.loadAnimation({
       container: elementRef.current,
@@ -14,5 +18,9 @@ export default function useLottieAnimation(animationData, elementRef) {
     });
   }
 
-  return ref.current;
+  const stopAnimation = React.useCallback(() => {
+    if (ref.current !== null) lottie.stop();
+  }, [elementRef]);
+
+  return [ref.current, stopAnimation];
 }

--- a/src/renderer/hooks/useTimeout.js
+++ b/src/renderer/hooks/useTimeout.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function useTimeout() {
+  const timeoutIds = React.useRef([]);
+
+  React.useEffect(() => {
+    return () =>
+      timeoutIds.current.forEach(timeoutId => clearTimeout(timeoutId));
+  }, []);
+
+  function addTimeout(callback, delay) {
+    const timeoutId = setTimeout(callback, delay);
+    timeoutIds.current.push(timeoutId);
+  }
+
+  return addTimeout;
+}

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -135,8 +135,6 @@ const Home = observer(() => {
         setCurrentKey(key);
         openDeleteKeyDialog();
         break;
-      case 'OPEN_PROFILE':
-        break;
       case 'ADD_LABEL':
         setCurrentKey(key);
         openInputLabelDialog();

--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -82,6 +82,14 @@ const AddKey = observer(({ onNext }) => {
     );
   }, [sessionStore.provider, sessionStore.mode, sessionStore.username]);
 
+  // Close all notifications on unmount.
+  // Using unmount method of useEffect() to remove all notifications displayed.
+  React.useEffect(() => {
+    return () => {
+      toaster.closeAll();
+    };
+  }, []);
+
   const openConfirmationDialog = () => setShowConfirmationDialog(true);
   const closeConfirmationDialog = () => setShowConfirmationDialog(false);
 

--- a/src/renderer/pages/sshsetup/CloneRepo.js
+++ b/src/renderer/pages/sshsetup/CloneRepo.js
@@ -85,7 +85,6 @@ const CloneRepo = observer(() => {
       bigAnimation.play();
       bigAnimation.addEventListener('complete', () => {
         setBigAnimShown(true);
-        lottie.destroy();
       });
     }
   }

--- a/src/renderer/pages/sshsetup/CloneRepo.js
+++ b/src/renderer/pages/sshsetup/CloneRepo.js
@@ -12,12 +12,15 @@ import useWindowSize from '../../hooks/useWindowSize';
 // Reveal animation
 import { Reveal, RevealGlobalStyles } from 'react-genie';
 import toaster, { Position } from 'toasted-notes';
+import lottie from 'lottie-web';
 
 import { useStore } from '../../StoreProvider';
 import { observer } from 'mobx-react-lite';
 
 import CloneRepoDialog from '../../components/CloneRepoDialog';
 import UpdateRemoteDialog from '../../components/UpdateRemoteDialog';
+
+import useTimeout from '../../hooks/useTimeout';
 
 const CloneRepo = observer(() => {
   const { sessionStore } = useStore();
@@ -26,6 +29,8 @@ const CloneRepo = observer(() => {
   const [showUpdateRemoteDialog, setShowUpdateRemoteDialog] = React.useState(
     false
   );
+
+  const addTimeout = useTimeout(); // Custom hook to auto clear all setTimeout()'s whenever page is unmounted.
 
   // Animation stuff
 
@@ -62,11 +67,10 @@ const CloneRepo = observer(() => {
     }
   }, [desktopFolder]);
 
-  // Close all notifications on unmount.
-  // Using unmount method of useEffect() to remove all notifications displayed.
   React.useEffect(() => {
     return () => {
       toaster.closeAll();
+      lottie.destroy();
     };
   }, []);
 
@@ -81,6 +85,7 @@ const CloneRepo = observer(() => {
       bigAnimation.play();
       bigAnimation.addEventListener('complete', () => {
         setBigAnimShown(true);
+        lottie.destroy();
       });
     }
   }
@@ -88,7 +93,7 @@ const CloneRepo = observer(() => {
   function playSetupSuccessAnimation() {
     if (setupSuccessAnimation !== null) {
       setupSuccessAnimation.play();
-      setTimeout(() => {
+      addTimeout(() => {
         setRecycleConfetti(false);
         if (sessionStore.mode === 'MULTI') {
           showNotification();
@@ -98,7 +103,7 @@ const CloneRepo = observer(() => {
   }
 
   function showNotification() {
-    setTimeout(() => {
+    addTimeout(() => {
       toaster.notify(
         ({ onClose }) => {
           return (

--- a/src/renderer/pages/sshsetup/CloneRepo.js
+++ b/src/renderer/pages/sshsetup/CloneRepo.js
@@ -12,7 +12,6 @@ import useWindowSize from '../../hooks/useWindowSize';
 // Reveal animation
 import { Reveal, RevealGlobalStyles } from 'react-genie';
 import toaster, { Position } from 'toasted-notes';
-import lottie from 'lottie-web';
 
 import { useStore } from '../../StoreProvider';
 import { observer } from 'mobx-react-lite';
@@ -37,13 +36,16 @@ const CloneRepo = observer(() => {
   // For big loader shown on page load
   const [bigAnimShown, setBigAnimShown] = React.useState(false);
   const bigAnimRef = React.useRef(null);
-  const bigAnimation = useLottieAnimation(bigLoaderAnimData, bigAnimRef);
+  const [bigAnimation, stopBigAnimation] = useLottieAnimation(
+    bigLoaderAnimData,
+    bigAnimRef
+  );
 
   // For success animtation shown next to All Setup text.
-  const setupSuccessAnimRef = React.useRef(null);
-  const setupSuccessAnimation = useLottieAnimation(
+  const successAnimRef = React.useRef(null);
+  const [successAnimation, stopSuccessAnimation] = useLottieAnimation(
     setupSuccessAnimData,
-    setupSuccessAnimRef
+    successAnimRef
   );
 
   // Used by React Confetti
@@ -70,7 +72,8 @@ const CloneRepo = observer(() => {
   React.useEffect(() => {
     return () => {
       toaster.closeAll();
-      lottie.destroy();
+      stopBigAnimation();
+      stopSuccessAnimation();
     };
   }, []);
 
@@ -90,8 +93,8 @@ const CloneRepo = observer(() => {
   }
 
   function playSetupSuccessAnimation() {
-    if (setupSuccessAnimation !== null) {
-      setupSuccessAnimation.play();
+    if (successAnimation !== null) {
+      successAnimation.play();
       addTimeout(() => {
         setRecycleConfetti(false);
         if (sessionStore.mode === 'MULTI') {
@@ -173,7 +176,7 @@ const CloneRepo = observer(() => {
           <Reveal onShowDone={() => playSetupSuccessAnimation()}>
             <h2 className="text-3xl text-gray-900">All Setup</h2>
           </Reveal>
-          <div className="w-24 h-24 -ml-6" ref={setupSuccessAnimRef} />
+          <div className="w-24 h-24 -ml-6" ref={successAnimRef} />
         </div>
 
         {sessionStore.mode === 'MULTI' ? (


### PR DESCRIPTION
- Cancel notifications on unmount in `AddKey` screen to avoid showing notifications once the screen is closed. We somehow missed this in AddKey screen.
Changed following hooks:

**useTimeout:**
> Created custom hook for it `useTimeout()` which basically cancels all timeouts on unmount without main component having to deal with it. We need it because in CloneRepo screen we show animations and notification with timeouts. So, if we user exists early we can cancel those timeouts thereby not allowing callback code inside timeout to run resulting into delayed notification on another screen.

**useLottieAnimtion:**
> Apart from cancelling timeouts we also need to make sure we **stop** lottie animations using `anim.stop()` method.  We weren't handling it resulting into memory leak. 
Added animation stop and clean up logic in useLottieAnimation hook by exposing additional method from this hook called `stopAnimation`. So, now this hook returns tuple with actual animation instance and stopAnimation method to stop that particular animation. Ideally we could have used animation instance and called `stop()` method on it but that doesn't seems to work maybe animation instance becomes null when associated container of it is unmounted and no longer present in DOM. 
That is the reason we're providing another method from this hook. 

- Remove **"Open Profile"** menu action.
- Shitty workaround for aligning images in `ProviderAccordian` component.