### PR TITLE
Bug : Fixup UI

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -83,8 +83,8 @@ async function overrideExistingKeys(fileName) {
   const publicKeyFilePath = path.join(sshDir, `${fileName}.pub`);
 
   const [privateKeyDeleted, publickKeyDeleted] = await Promise.all([
-    fsAsync.unlinkFile(privateKeyFilePath),
-    fsAsync.unlinkFile(publicKeyFilePath),
+    fsAsync.unlink(privateKeyFilePath),
+    fsAsync.unlink(publicKeyFilePath),
   ]);
 
   return [privateKeyDeleted, publickKeyDeleted];

--- a/src/main/import-export-store.js
+++ b/src/main/import-export-store.js
@@ -4,8 +4,8 @@ const { KeyStore: store } = require('./ElectronStore');
 const importStore = async () => {
   const keyStore = store.get('keyStore');
   try {
-    if (keyStore.length === 0) {
-      const sshConfig = await getSshConfig();
+    const sshConfig = await getSshConfig();
+    if (keyStore.length === 0 || keyStore.length !== sshConfig.length) {
       store.set('keyStore', sshConfig);
       return store.get('keyStore');
     }

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -31,7 +31,7 @@ function createWindow() {
 
 function setAppMenu() {
   const isMac = process.platform === 'darwin';
-  const CHANGELOG_BASE_URL = `${web_base_url}/changelog`;
+  const CHANGELOG_BASE_URL = `https://headwayapp.co/ssh-git-changelog`;
 
   const template = [
     // App menu

--- a/src/renderer/components/ProviderAccordion.js
+++ b/src/renderer/components/ProviderAccordion.js
@@ -72,9 +72,11 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
                         {key.mode === 'SINGLE'
                           ? singleModeActions.map((action, index) => (
                               <li
-                                className={`${index === 0 ? `rounded-t` : ``} ${
-                                  index === 2
-                                    ? `rounded-b`
+                                className={`${
+                                  index === 0 ? `rounded-t-md` : ``
+                                } ${
+                                  index === 1
+                                    ? `rounded-b-md`
                                     : `border-b-2 border-gray-200`
                                 } bg-gray-100 hover:bg-gray-300 py-2 px-4 block whitespace-no-wrap`}
                                 key={action.name}
@@ -86,9 +88,11 @@ const ProviderAccordion = ({ keys, onNewSshKeyClicked, onActionClicked }) => {
                             ))
                           : multiModeActions.map((action, index) => (
                               <li
-                                className={`${index === 0 ? `rounded-t` : ``} ${
-                                  index === 3
-                                    ? `rounded-b`
+                                className={`${
+                                  index === 0 ? `rounded-t-md` : ``
+                                } ${
+                                  index === 2
+                                    ? `rounded-b-md`
                                     : `border-b-2 border-gray-200`
                                 } bg-gray-100 hover:bg-gray-300 py-2 px-4 block whitespace-no-wrap`}
                                 key={action.name}

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -194,8 +194,8 @@ const Home = observer(() => {
             </div>
             <ProviderAccordion
               keys={keyStore.keysGroupByProvider}
-              onNewSshKeyClicked={_provider => {
-                navigate('/oauth/connect');
+              onNewSshKeyClicked={provider => {
+                navigate('/oauth/connect', { state: { provider } });
               }}
               onActionClicked={onActionClicked}
             />

--- a/src/renderer/pages/Home.js
+++ b/src/renderer/pages/Home.js
@@ -121,6 +121,22 @@ const Home = observer(() => {
     }
   }
 
+  async function refreshStore() {
+    const storeSnapshot = await window.ipc.callMain('import-store');
+    keyStore.clear();
+    keyStore.addKeys(storeSnapshot);
+    toaster.notify(
+      () => {
+        return (
+          <div className="py-2 px-4 rounded shadow-md bg-blue-500 text-white font-semibold text-center text-lg mt-20 mr-4">
+            Updated Successfully
+          </div>
+        );
+      },
+      { duration: 1000, position: Position['top'] }
+    );
+  }
+
   function onActionClicked(actionType, key) {
     switch (actionType) {
       case 'CLONE_REPO':
@@ -158,10 +174,24 @@ const Home = observer(() => {
       <div className="my-12 flex flex-col justify-start flex-wrap max-w-2xl xl:max-w-4xl mx-auto">
         {keyStore.totalNoOfKeys > 0 ? (
           <div>
-            <h1 className="text-lg text-gray-700 text-right mb-8">
-              Total 🔑 :{' '}
-              <span className="font-extrabold">{keyStore.totalNoOfKeys}</span>
-            </h1>
+            <div className="flex flex-row justify-between items-center mb-12">
+              <h1 className="inline text-lg text-gray-700 text-right">
+                Total 🔑 :{' '}
+                <span className="font-extrabold">{keyStore.totalNoOfKeys}</span>
+              </h1>
+              <svg
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                class="w-4 h-4 mr-2 text-gray-700 inline cursor-pointer"
+                onClick={refreshStore}>
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+              </svg>
+            </div>
             <ProviderAccordion
               keys={keyStore.keysGroupByProvider}
               onNewSshKeyClicked={_provider => {

--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -21,14 +21,14 @@ const AddKey = observer(({ onNext }) => {
 
   // Used for check mark animation when key is copied
   const keyLottieRef = React.useRef(null);
-  const keyCopyAnimation = useLottieAnimation(
+  const [keyCopyAnimation] = useLottieAnimation(
     checkMarkAnimationData,
     keyLottieRef
   );
 
   // Used for check mark animation when link is opened
   const linkLottieRef = React.useRef(null);
-  const linkOpenAnimation = useLottieAnimation(
+  const [linkOpenAnimation] = useLottieAnimation(
     checkMarkAnimationData,
     linkLottieRef
   );

--- a/src/renderer/pages/sshsetup/ConnectAccount.js
+++ b/src/renderer/pages/sshsetup/ConnectAccount.js
@@ -18,7 +18,7 @@ import { trackEvent } from '../../analytics';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '../../StoreProvider';
 
-const ConnectAccount = observer(({ onNext }) => {
+const ConnectAccount = observer(({ onNext, location }) => {
   // Using context to access Auth store
   const { sessionStore, keyStore } = useStore();
 
@@ -34,6 +34,9 @@ const ConnectAccount = observer(({ onNext }) => {
 
   React.useEffect(() => {
     sessionStore.resetKey();
+    if (location.state.provider) {
+      sessionStore.addProvider(location.state.provider);
+    }
   }, []);
 
   React.useEffect(() => {

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -94,29 +94,31 @@ const KeyStore = types
       if (keyIndex !== -1) self.sshKeys.splice(keyIndex, 1);
     },
     addKeys(keys) {
-      keys.forEach(key => {
-        const {
-          provider,
-          path,
-          mode,
-          username = '',
-          email = '',
-          avatar_url = '',
-          bitbucket_uuid = '',
-          label = '',
-        } = key;
+      if (keys && keys.length > 0) {
+        keys.forEach(key => {
+          const {
+            provider,
+            path,
+            mode,
+            username = '',
+            email = '',
+            avatar_url = '',
+            bitbucket_uuid = '',
+            label = '',
+          } = key;
 
-        self.sshKeys.push({
-          provider,
-          path,
-          mode,
-          username,
-          email,
-          avatar_url,
-          bitbucket_uuid,
-          label,
+          self.sshKeys.push({
+            provider,
+            path,
+            mode,
+            username,
+            email,
+            avatar_url,
+            bitbucket_uuid,
+            label,
+          });
         });
-      });
+      }
     },
     addUsername(key, username) {
       const keyIndex = self.sshKeys.findIndex(
@@ -137,6 +139,9 @@ const KeyStore = types
         const updatedKey = { ...key, label };
         self.sshKeys.splice(keyIndex, 1, updatedKey);
       }
+    },
+    clear() {
+      self.sshKeys = [];
     },
   }))
   .views(self => ({


### PR DESCRIPTION
- Fixed **Changelog** url in app menu pointing to [headwayapp](https://headwayapp.co/ssh-git-changelog)
- Added option to **refresh store **  and sync it with config file if there is mismatch in no. of keys in keyStore(MobX) and config file.
- Fix Css border issues in Menu. Forgot to add correct index for adding round border when we removed 'Open Profile' action in last PR.
- Fix **AddKey** screen useLottieAnimation return value. It is tuple now.
- Select particular provider by default in Connect Account screen.
     > When user tries to generate new key from provider section with "New SSH Key" button, we pass on provider in state using `navigate('/oauth/connect', {state : {provider}})` method in Reach Router and access it in ConnectAccount screen using `props.location.state.provider` and depending on whether it is present or not we set provider using `sessionStore.addProvider(provider)`.
