### PR TITLE
Feat : Copy Connect Account link

### DIFF
--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -21,6 +21,7 @@ function showWindow(window) {
 
 async function handleAppURL(callbackUrl, mainWindow) {
   showWindow(mainWindow);
+  ipc.callFocusedRenderer('connecting-account');
 
   const authState = parseAppURL(callbackUrl);
   if (!authState) {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,4 +1,5 @@
 window.ipc = require('electron-better-ipc').ipcRenderer; // Using electron-better-ipc for better ipc comm api.
+window.clipboard = require('electron').clipboard;
 
 // Init sentry for renderer process and catch global errors on window
 const { initSentry, catchGlobalErrors } = require('../lib/crash-reporter');

--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -33,7 +33,6 @@ const AddKey = observer(({ onNext }) => {
     linkLottieRef
   );
 
-  const textareaRef = React.useRef(null); // need ref to get textarea's node to use `copy` command on it for copying to clipboard.
   const [publicKey, setPublicKey] = React.useState(' '); // set public key's content
 
   // Used to keep check of state whether key was copied and link was opened by the user and show errors accordingly
@@ -148,12 +147,7 @@ const AddKey = observer(({ onNext }) => {
   // Copies the content of `textarea` to the clipboard
   function onCopyToClipboardClicked(event) {
     event.preventDefault();
-
-    let textarea = textareaRef.current;
-    textarea.select();
-    textarea.setSelectionRange(0, 99999); //Not sure if this is the correct way.
-    document.execCommand('copy');
-
+    window.clipboard.writeText(publicKey);
     setKeyCopied(true); //Set "keyCopied" state to true indicating that copy key task is done by user
 
     // Show toast
@@ -192,23 +186,8 @@ const AddKey = observer(({ onNext }) => {
     trackEvent('setup-flow', 'link-opened');
   }
 
-  // Add listener for textarea change event which we don't allow to change to keep
-  // React happy. Not sure if this is the correct way.
-  function onPublicKeyChange(event) {
-    event.preventDefault();
-    //Don't allow changing public key content
-  }
-
   return (
     <div>
-      <textarea
-        ref={textareaRef}
-        rows="1"
-        cols="1"
-        value={publicKey}
-        onChange={onPublicKeyChange}
-        className="-ml-24"
-      />
       <div className="flex flex-col items-center justify-center">
         <div className="mt-4 w-96 h-128 bg-gray-100 rounded-lg shadow-md flex flex-col justify-center">
           <h2 className="mx-16 mt-6 text-xl font-semibold text-center text-gray-700">

--- a/src/renderer/pages/sshsetup/AddKey.js
+++ b/src/renderer/pages/sshsetup/AddKey.js
@@ -144,7 +144,7 @@ const AddKey = observer(({ onNext }) => {
   }
 
   // Triggered When "Copy" link is clicked.
-  // Copies the content of `textarea` to the clipboard
+  // Copies the content to the clipboard using Electron's clipboard api
   function onCopyToClipboardClicked(event) {
     event.preventDefault();
     window.clipboard.writeText(publicKey);

--- a/src/renderer/pages/sshsetup/ConnectAccount.js
+++ b/src/renderer/pages/sshsetup/ConnectAccount.js
@@ -79,6 +79,18 @@ const ConnectAccount = observer(({ onNext, location }) => {
     };
   }, [sessionStore.state]);
 
+  React.useEffect(() => {
+    let dispose;
+
+    dispose = window.ipc.answerMain('connecting-account', () => {
+      dispatch({ type: 'FETCH_INIT' });
+    });
+
+    return () => {
+      if (dispose) dispose();
+    };
+  }, []);
+
   // Click listener for button `Connect`.
   function connectToProvider() {
     dispatch({ type: 'FETCH_INIT' });

--- a/src/renderer/pages/sshsetup/ConnectAccount.js
+++ b/src/renderer/pages/sshsetup/ConnectAccount.js
@@ -1,5 +1,6 @@
 // external libs
 import React from 'react';
+import toaster, { Position } from 'toasted-notes';
 
 import { getOauthUrlsForBasicInfo } from '../../service/api';
 import fetchReducer from '../../reducers/fetchReducer';
@@ -37,6 +38,10 @@ const ConnectAccount = observer(({ onNext, location }) => {
     if (location.state.provider) {
       sessionStore.addProvider(location.state.provider);
     }
+  }, []);
+
+  React.useEffect(() => {
+    return () => toaster.closeAll();
   }, []);
 
   React.useEffect(() => {
@@ -85,6 +90,31 @@ const ConnectAccount = observer(({ onNext, location }) => {
     trackEvent('setup-flow', `${sessionStore.provider}-connect`);
   }
 
+  function onCopyToClipboardClicked() {
+    const { url, state } = getOauthUrlsForBasicInfo(sessionStore.provider);
+
+    sessionStore.addState(state);
+    window.clipboard.writeText(url);
+    // Show toast
+    toaster.notify(
+      () => {
+        return (
+          <div className="py-2 px-4 rounded shadow-md bg-green-500 text-white font-medium text-center text-base mt-20 mr-4">
+            <h1 className="font-semibold text-left">Key copied to clipboard</h1>
+            <span className="mt-2">
+              Paste it in your browser to connect account
+            </span>
+          </div>
+        );
+      },
+      {
+        duration: 2500,
+        position: Position['top-right'],
+      }
+    );
+    trackEvent('setup-flow', `${sessionStore.provider}-connect`);
+  }
+
   return (
     <>
       <h1 className="text-2xl text-gray-900 text-center mt-8">
@@ -130,6 +160,16 @@ const ConnectAccount = observer(({ onNext, location }) => {
             : data
             ? 'Success!'
             : 'Connect'}
+        </button>
+      </div>
+      <div className="absolute right-0 bottom-0 mr-16 mb-8">
+        <span className="text-gray-800 text-base">
+          Want to connect account logged in a specific browser?
+        </span>
+        <button
+          className="ml-2 font-medium border-b-2 border-blue-500 hover:border-blue-700 text-blue-500 hover:text-blue-700 text-base focus:outline-none"
+          onClick={onCopyToClipboardClicked}>
+          Copy link
         </button>
       </div>
     </>

--- a/src/renderer/pages/sshsetup/ConnectAccount.js
+++ b/src/renderer/pages/sshsetup/ConnectAccount.js
@@ -124,7 +124,7 @@ const ConnectAccount = observer(({ onNext, location }) => {
         position: Position['top-right'],
       }
     );
-    trackEvent('setup-flow', `${sessionStore.provider}-connect`);
+    trackEvent('setup-flow', `${sessionStore.provider}-connect-copy-link`);
   }
 
   return (


### PR DESCRIPTION
- Users can now copy connect account link on their clipboard 📋 and open in their browser of choice. This is for users using multiple browsers with different account logged in those all at once and wish to connect to account logged in a particular browser by copying the link.

- Sending one more ipc event `connecting-account` from main process to handle copy account link scenario for Github connect which involves api call(and some delay as a result) to get access token after we receive redirect Uri from user. So, using this ipc event in renderer process we could change connect button state reflecting that connecting account is in process to the user.

- I was zero days old when i learned that there exists [Clipboard api](https://www.electronjs.org/docs/api/clipboard) in electron and used it to copy the link contents to clipboard. Added clipboard to window using preload script and accessing it in render process using `window.clipboard`.

- Removed Textarea workaround in AddKey screen with Electron's Clipboard api. 